### PR TITLE
Fixed bug that broke "not implemented" message

### DIFF
--- a/Void/Void.Core/CoreControllers.fs
+++ b/Void/Void.Core/CoreControllers.fs
@@ -28,7 +28,7 @@ type EditorController() =
         | Command.Yank
         | Command.Put
         | Command.FormatCurrentLine ->
-            x.handleCommand notImplemented 
+            notImplemented 
         | Command.ViewTestBuffer ->
             let buffer = Buffer.testFile
             _editorState <- Editor.viewFile _editorState buffer


### PR DESCRIPTION
I branched off the original commit that broke it, but because things were kind of in an in-between state you couldn't tell it had broken in.
