### PR TITLE
Distribute messaging subscription to the services themselves

### DIFF
--- a/src/Void.Core/BaseMessageInterfaces.fs
+++ b/src/Void.Core/BaseMessageInterfaces.fs
@@ -11,3 +11,8 @@ module ``This module is auto-opened to provide a null message`` =
         interface Message
     let noMessage = NoMessage :> Message
 
+type Handle<'TMsg when 'TMsg :> Message> =
+    'TMsg -> Message
+
+type SubscribeToBus =
+    abstract member subscribe<'TMsg when 'TMsg :> Message> : Handle<'TMsg> -> unit

--- a/src/Void.Core/BufferList.fs
+++ b/src/Void.Core/BufferList.fs
@@ -83,12 +83,7 @@ module BufferList =
             (bufferList, noMessage)
 
     module Service =
-        let private eventHandler bufferList =
-            Service.wrap bufferList handleEvent
-
-        let private commandHandler bufferList =
-            Service.wrap bufferList handleCommand
-
-        let build() =
+        let subscribe (subscribeHandler : SubscribeToBus) =
             let bufferList = ref empty
-            (eventHandler bufferList, commandHandler bufferList)
+            subscribeHandler.subscribe <| Service.wrap bufferList handleCommand
+            subscribeHandler.subscribe <| Service.wrap bufferList handleEvent

--- a/src/Void.Core/Filesystem.fs
+++ b/src/Void.Core/Filesystem.fs
@@ -59,3 +59,7 @@ module Filesystem =
         | Command.SaveToDisk (path, lines) ->
             writeLines path lines :> Message
         | _ -> noMessage
+
+    module Service =
+        let subscribe (subscribeHandler : SubscribeToBus) =
+            subscribeHandler.subscribe handleCommand

--- a/src/Void.Core/Notifications.fs
+++ b/src/Void.Core/Notifications.fs
@@ -31,8 +31,8 @@ module Notifications =
         | _ -> (notifications, noMessage)
 
     module Service =
-        let build() =
+        let subscribe (subscribeHandler : SubscribeToBus) =
             let notifications = ref []
-            let eventHandler = Service.wrap notifications handleEvent
-            let commandHandler = Service.wrap notifications handleCommand
-            (eventHandler, commandHandler)
+            subscribeHandler.subscribe <| Service.wrap notifications handleEvent
+            subscribeHandler.subscribe  <| Service.wrap notifications handleCommand
+             

--- a/src/Void.Spec/VoidSpec.fs
+++ b/src/Void.Spec/VoidSpec.fs
@@ -19,8 +19,8 @@ type ``Void``() =
     [<Test>]
     member x.``When I have freshly opened Vim with one window, when I enter the quit command, then the editor exists``() =
         let inputModeChanger = InputModeChangerStub()
-        let messagingSystem = Init.buildVoid inputModeChanger
-        Init.launchVoid messagingSystem
+        let bus = Init.buildVoid inputModeChanger
+        Init.launchVoid bus
         let closed = ref false
         let closeHandler event =
             match event with
@@ -28,7 +28,7 @@ type ``Void``() =
                 closed := true
             | _ -> ()
             noMessage
-        messagingSystem.CoreEventChannel.addHandler closeHandler
+        bus.subscribe closeHandler
 
         match inputModeChanger.getInputHandler() with
         | InputMode.KeyPresses handler ->

--- a/src/Void.UI/Program.cs
+++ b/src/Void.UI/Program.cs
@@ -15,11 +15,11 @@ namespace Void.UI
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             var inputModeChanger = new WinFormsInputModeChanger();
-            var messagingSystem = Init.buildVoid(inputModeChanger);
-            var view = new MainForm(messagingSystem.Bus, inputModeChanger);
-            messagingSystem.CoreEventChannel.addHandler(FSharpFuncUtil.Create<CoreEvent, Message>(view.HandleEvent));
-            messagingSystem.VMEventChannel.addHandler(FSharpFuncUtil.Create<VMEvent, Message>(view.HandleViewModelEvent));
-            Init.launchVoid(messagingSystem);
+            Bus bus = Init.buildVoid(inputModeChanger);
+            var view = new MainForm(bus, inputModeChanger);
+            bus.subscribe(FSharpFuncUtil.Create<CoreEvent, Message>(view.HandleEvent));
+            bus.subscribe(FSharpFuncUtil.Create<VMEvent, Message>(view.HandleViewModelEvent));
+            Init.launchVoid(bus);
             Application.Run(view);
         }
     }

--- a/src/Void.ViewModel/CommandBar.fs
+++ b/src/Void.ViewModel/CommandBar.fs
@@ -73,11 +73,10 @@ module CommandBar =
         | CommandMode.Event.TextAppended text -> appendText text commandBar
         | CommandMode.Event.CommandCompleted -> (commandBar, noMessage)
 
-module CommandBarService =
-    open Void.Core
+    module Service =
+        open Void.Core
 
-    let build() =
-        let commandBar = ref CommandBar.hidden
-        let eventHandler = Service.wrap commandBar CommandBar.handleEvent
-        let commandModeEventHandler = Service.wrap commandBar CommandBar.handleCommandModeEvent
-        (eventHandler, commandModeEventHandler)
+        let subscribe (subscribeHandler : SubscribeToBus) =
+            let commandBar = ref hidden
+            subscribeHandler.subscribe <| Service.wrap commandBar handleEvent
+            subscribeHandler.subscribe <| Service.wrap commandBar handleCommandModeEvent

--- a/src/Void.ViewModel/NotifyUserOfEvent.fs
+++ b/src/Void.ViewModel/NotifyUserOfEvent.fs
@@ -20,3 +20,7 @@ module NotifyUserOfEvent =
                 | None -> noMessage
             | _ -> noMessage*)
         | _ -> noMessage
+
+    module Service =
+        let subscribe (subscribeHandler : SubscribeToBus) =
+            subscribeHandler.subscribe handleEvent

--- a/src/Void.ViewModel/WindowBufferMap.fs
+++ b/src/Void.ViewModel/WindowBufferMap.fs
@@ -82,9 +82,6 @@ module WindowBufferMap =
     module Service =
         open Void.Core
 
-        let private vmCommandHandler windowBufferMap =
-            Service.wrap windowBufferMap handleVMCommand
-
-        let build() =
+        let subscribe (subscribeHandler : SubscribeToBus) =
             let windowBufferMap = ref empty
-            vmCommandHandler windowBufferMap
+            subscribeHandler.subscribe <| Service.wrap windowBufferMap handleVMCommand

--- a/src/Void/Init.fs
+++ b/src/Void/Init.fs
@@ -30,7 +30,6 @@ module Init =
         |> changer.SetInputHandler
 
     let buildVoid inputModeChanger =
-        let notificationServiceEventHandler, notificationServiceCommandHandler = Notifications.Service.build()
         let bufferListEventHandler, bufferListCommandHandler = BufferList.Service.build()
         let editorService = EditorService()
         let commandBarHandleEvent, commandBarHandleCommandModeEvent = CommandBarService.build()
@@ -39,7 +38,6 @@ module Init =
         let coreCommandChannel =
             Channel [
                 bufferListCommandHandler
-                notificationServiceCommandHandler
                 viewService.handleCommand
                 editorService.handleCommand
             ]
@@ -48,7 +46,6 @@ module Init =
             Channel [
                 bufferListEventHandler
                 NotifyUserOfEvent.handleEvent
-                notificationServiceEventHandler
                 commandBarHandleEvent
                 viewService.handleEvent
             ]
@@ -66,12 +63,12 @@ module Init =
             ]
         let bus =
             Bus [
-                coreCommandChannel.publish
-                filesystemCommandChannel.publish
-                coreEventChannel.publish
-                commandModeEventChannel.publish
-                vmEventChannel.publish
-                vmCommandChannel.publish
+                coreCommandChannel
+                filesystemCommandChannel
+                coreEventChannel
+                commandModeEventChannel
+                vmEventChannel
+                vmCommandChannel
             ]
         let interpreter = Interpreter.init <| VoidScriptEditorModule(bus.publish).Commands
         let interpreterWrapper = InterpreterWrapperService interpreter
@@ -83,6 +80,8 @@ module Init =
         coreCommandChannel.addHandler modeService.handleCommand
         coreEventChannel.addHandler modeService.handleEvent
         commandModeEventChannel.addHandler modeService.handleCommandModeEvent
+
+        Notifications.Service.subscribe bus
 
         {
             CoreEventChannel = coreEventChannel

--- a/src/Void/Init.fs
+++ b/src/Void/Init.fs
@@ -32,7 +32,6 @@ module Init =
     let buildVoid inputModeChanger =
         let bufferListEventHandler, bufferListCommandHandler = BufferList.Service.build()
         let editorService = EditorService()
-        let commandBarHandleEvent, commandBarHandleCommandModeEvent = CommandBarService.build()
         let windowBufferVMCommandHandler = WindowBufferMap.Service.build()
         let viewService = ViewModelService()
         let coreCommandChannel =
@@ -46,12 +45,10 @@ module Init =
             Channel [
                 bufferListEventHandler
                 NotifyUserOfEvent.handleEvent
-                commandBarHandleEvent
                 viewService.handleEvent
             ]
         let commandModeEventChannel =
             Channel [
-                commandBarHandleCommandModeEvent
             ]
         let vmEventChannel =
             Channel [
@@ -82,6 +79,7 @@ module Init =
         commandModeEventChannel.addHandler modeService.handleCommandModeEvent
 
         Notifications.Service.subscribe bus
+        CommandBar.Service.subscribe bus
 
         {
             CoreEventChannel = coreEventChannel

--- a/src/Void/Messaging.fs
+++ b/src/Void/Messaging.fs
@@ -3,24 +3,37 @@
 open Void.Core
 open Void.ViewModel
 
+type Channel =
+    abstract member publish : Message -> Message seq
+    (* F# Why you no have type classes like Haskell!?!?!
+     * Now I will do ugly things, with long names! *)
+    abstract member getBoxedSubscribeActionIfTypeIs<'TMsg> : unit -> obj option
+    
+
 type Channel<'TIn when 'TIn :> Message>
     (
         handlers : ('TIn -> Message) list
     ) =
     let mutable _handlers = handlers
 
-    member x.publish (message : Message) =
-        match message with
-        | :? 'TIn as msg ->
-            Seq.map (fun handle -> handle msg) _handlers
-        | _ -> Seq.empty
-
     member x.addHandler handler =
         _handlers <- handler :: _handlers
 
+    interface Channel with
+        member x.publish (message : Message) =
+            match message with
+            | :? 'TIn as msg ->
+                Seq.map (fun handle -> handle msg) _handlers
+            | _ -> Seq.empty
+
+        member x.getBoxedSubscribeActionIfTypeIs<'TMsg>() =
+            if typeof<'TIn> = typeof<'TMsg>
+            then Some <| box x.addHandler
+            else None
+
 type Bus
     (
-        channels : (Message -> Message seq) list
+        channels : Channel list
     ) =
     let mutable _channels = channels
 
@@ -32,5 +45,15 @@ type Bus
             x.publish message
 
     member x.publish (message : Message) =
-        for publishToChannel in _channels do
-            publishToChannel message |> x.publishAll
+        for channel in _channels do
+            channel.publish message |> x.publishAll
+
+    interface SubscribeToBus with
+        member x.subscribe<'TMsg when 'TMsg :> Message> (handle : Handle<'TMsg>) =
+            let tryGetSubscribeAction (channel : Channel) =
+                channel.getBoxedSubscribeActionIfTypeIs<'TMsg>()
+            match List.choose tryGetSubscribeAction _channels with
+            | [subscribe] ->
+                handle
+                |> unbox<('TMsg -> Message) -> unit> subscribe
+            | _ -> ()


### PR DESCRIPTION
I was wasting too much time on debugging errors caused by forgetting to go to another file and register. This means that only the service itself much be registered; it subscribes it ones handlers for whatever message types it wants. A channel is auto-created if an appropriate channel cannot be found. This is a much more scalable, if somewhat more magical, approach to the messaging infrastructure. :boom:!
