### PR TITLE
Build Void with FAKE!! The way it should be.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
+tools/
 
 # Roslyn cache directories
 *.ide/
@@ -187,3 +188,10 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+# Vim
+*.swp
+*.swo
+
+# Fake
+.fake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: csharp
 solution: src/Void.sln
-install:
-- nuget restore src/Void.sln
-- nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner
+sudo: false
 script:
-- xbuild /p:Configuration=Release src/Void.sln
-- mono ./testrunner/NUnit.Runners.2.6.4/tools/nunit-console.exe ./src/Void*Spec/bin/Release/Void*Spec.dll
+- ./build.sh
 notifications:
   slack:
     secure: ClFSQvKGQe0JN8iircAYscyYZT0r+AFn9iUdd3WctxxG6jQTZGkjeAd4XvecTarlhGU/xXe13m2E2PLY7QN3AJIkELdp5HppoM2ih+dz8kGQzTYBVKMXHf533biMQrSgDzqAzUpsLuWh09Yu85LTfrQuqoSA5vsUuGIOzAzgdJg=

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,7 @@
 version: 0.0.0.{build}
-build:
-  verbosity: minimal
-test:
-  assemblies: '**\*.Spec.dll'
+build_script:
+- ./build.bat
+test: off
 notifications:
 - provider: Slack
   auth_token:

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,3 @@
+@echo off
+"src\.nuget\NuGet.exe" "Install" "FAKE" "-OutputDirectory" "src\packages" "-ExcludeVersion"
+"src\packages\FAKE\tools\Fake.exe" build.fsx

--- a/build.fsx
+++ b/build.fsx
@@ -1,0 +1,54 @@
+#r "./src/packages/FAKE/tools/FakeLib.dll"
+open Fake
+open Fake.NuGet.Install
+
+RestorePackages()
+
+// Properties
+let buildDir = "./build/"
+
+// Targets
+Target "Clean" (fun _ ->
+    CleanDirs [buildDir]
+)
+
+Target "Compile" (fun _ ->
+   !! "src/**/*.fsproj"
+   |> MSBuildRelease buildDir "Build"
+   |> Log "Compile-Output: "
+)
+
+(* If the build ends up having more NuGet dependencies than this, I should
+ * probably make a packages.config for it instead, and make this target
+ * "AcquireBuildDependencies". "NUnit.Runners" can simply be replaced with
+ * "packages.config". *)
+Target "AcquireUnitTestRunner" (fun _ ->
+    "NUnit.Runners"
+    |> NugetInstall (fun p ->
+        { p with
+            ToolPath = "src/.nuget/NuGet.exe"
+            OutputDirectory = "tools/"
+            ExcludeVersion = true })
+)
+
+Target "Test" (fun _ ->
+    !! (buildDir + "*.Spec.dll")
+    |> NUnit (fun p ->
+        { p with
+            DisableShadowCopy = true
+            OutputFile = buildDir + "TestResults.xml" })
+)
+
+Target "Default" (fun _ ->
+    trace "Completed!"
+)
+
+// Dependencies
+"Clean"
+  ==> "Compile"
+  ==> "AcquireUnitTestRunner"
+  ==> "Test"
+  ==> "Default"
+
+// start build
+RunTargetOrDefault "Default"

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ FAKE_BIN=$PACKAGE_DIR/FAKE/tools/FAKE.exe
 chmod +x $NUGET_BIN
 [ -f "$FAKE_BIN" ] || mono $NUGET_BIN Install FAKE -OutputDirectory $PACKAGE_DIR -ExcludeVersion
 chmod +x $FAKE_BIN
-$FAKE_BIN build.fsx
+mono $FAKE_BIN build.fsx
 exitcode=$?
 git checkout $NUGET_BIN
 exit $exitcode

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,9 @@ NUGET_BIN=$NUGET_DIR/NuGet.exe
 FAKE_BIN=$PACKAGE_DIR/FAKE/tools/FAKE.exe
 
 chmod +x $NUGET_BIN
-[ -f "$FAKE_BIN" ] || $NUGET_BIN Install FAKE -OutputDirectory $PACKAGE_DIR -ExcludeVersion
+[ -f "$FAKE_BIN" ] || mono $NUGET_BIN Install FAKE -OutputDirectory $PACKAGE_DIR -ExcludeVersion
 chmod +x $FAKE_BIN
 $FAKE_BIN build.fsx
+exitcode=$?
 git checkout $NUGET_BIN
+exit $exitcode

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+ROOT_DIR=$PWD
+SOURCE_DIR=$PWD/src
+NUGET_DIR=$SOURCE_DIR/.nuget
+PACKAGE_DIR=$SOURCE_DIR/packages
+NUGET_BIN=$NUGET_DIR/NuGet.exe
+FAKE_BIN=$PACKAGE_DIR/FAKE/tools/FAKE.exe
+
+git update-index --assume-unchanged $NUGET_BIN
+chmod +x $NUGET_BIN
+[ -f "$FAKE_BIN" ] || $NUGET_BIN Install FAKE -OutputDirectory $PACKAGE_DIR -ExcludeVersion
+chmod +x $FAKE_BIN
+$FAKE_BIN build.fsx

--- a/build.sh
+++ b/build.sh
@@ -7,8 +7,8 @@ PACKAGE_DIR=$SOURCE_DIR/packages
 NUGET_BIN=$NUGET_DIR/NuGet.exe
 FAKE_BIN=$PACKAGE_DIR/FAKE/tools/FAKE.exe
 
-git update-index --assume-unchanged $NUGET_BIN
 chmod +x $NUGET_BIN
 [ -f "$FAKE_BIN" ] || $NUGET_BIN Install FAKE -OutputDirectory $PACKAGE_DIR -ExcludeVersion
 chmod +x $FAKE_BIN
 $FAKE_BIN build.fsx
+git checkout $NUGET_BIN


### PR DESCRIPTION
Need to add a `build.bat` or `build.ps1` for Windows at some point.

Also might be good to have Travis and AppVeyor kick off the FAKE build if possible.
