### PR TITLE
j/k movement for normal mode

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -43,17 +43,26 @@ Target "Test" (fun _ ->
             OutputFile = buildDir + "TestResults.xml" })
 )
 
-Target "Default" (fun _ ->
-    trace "Completed!"
+Target "Rebuild" (fun _ ->
+    trace "Rebuild completed!"
+)
+
+Target "JustRunTests" (fun _ ->
+    trace "Test run completed!"
 )
 
 // Dependencies
+"Test"
+  ==> "JustRunTests"
+
 "Clean"
   ==> "RestorePackages"
   ==> "Compile"
   ==> "AcquireUnitTestRunner"
-  ==> "Test"
-  ==> "Default"
+  ==> "Rebuild"
+
+"Test"
+  ==> "Rebuild"
 
 // start build
-RunTargetOrDefault "Default"
+RunTargetOrDefault "Rebuild"

--- a/src/Void.Core.Spec/BufferSpec.fs
+++ b/src/Void.Core.Spec/BufferSpec.fs
@@ -72,34 +72,34 @@ type ``Moving the cursor in a buffer``() =
     member x.``down one line should succeed within a two-line buffer``() =
         Buffer.handleMoveCursorByRows twoLineBuffer j
         |> snd
-        |> should equal (BufferEvent.CursorMovedTo { Column = 0<mColumn>; Row = 1<mRow> })
+        |> should equal (BufferEvent.CursorMoved(CellGrid.originCell, { Column = 0<mColumn>; Row = 1<mRow> }))
 
     [<Test>]
     member x.``moving up one line should undo moving down one line``() =
         let moved = Buffer.handleMoveCursorByRows twoLineBuffer j |> fst
         Buffer.handleMoveCursorByRows moved k
-        |> shouldEqual (twoLineBuffer, BufferEvent.CursorMovedTo CellGrid.originCell :> Message)
+        |> shouldEqual (twoLineBuffer, BufferEvent.CursorMoved({ Column = 0<mColumn>; Row = 1<mRow> }, CellGrid.originCell) :> Message)
 
     [<Test>]
     member x.``down three lines should succeed within a five-line buffer``() =
         Buffer.handleMoveCursorByRows fiveLineBuffer ``3j``
         |> snd
-        |> should equal (BufferEvent.CursorMovedTo { Column = 0<mColumn>; Row = 3<mRow> })
+        |> should equal (BufferEvent.CursorMoved(CellGrid.originCell, { Column = 0<mColumn>; Row = 3<mRow> }))
 
     [<Test>]
     member x.``moving up three lines should undo moving down three lines``() =
         let moved = Buffer.handleMoveCursorByRows fiveLineBuffer ``3j`` |> fst
         Buffer.handleMoveCursorByRows moved ``3k``
-        |> shouldEqual (fiveLineBuffer, BufferEvent.CursorMovedTo CellGrid.originCell :> Message)
+        |> shouldEqual (fiveLineBuffer, BufferEvent.CursorMoved({ Column = 0<mColumn>; Row = 3<mRow> }, CellGrid.originCell) :> Message)
 
     [<Test>]
     member x.``trying to move down five lines within a five-line buffer should not overshoot``() =
         Buffer.handleMoveCursorByRows fiveLineBuffer ``5j``
         |> snd
-        |> shouldEqual (BufferEvent.CursorMovedTo { Column = 0<mColumn>; Row = 4<mRow> })
+        |> shouldEqual (BufferEvent.CursorMoved(CellGrid.originCell, { Column = 0<mColumn>; Row = 4<mRow> }))
 
     [<Test>]
     member x.``moving up five lines in a five-line buffer from the bottom should not overshoot``() =
         let moved = Buffer.handleMoveCursorByRows fiveLineBuffer ``5j`` |> fst
         Buffer.handleMoveCursorByRows moved ``5k``
-        |> shouldEqual (fiveLineBuffer, BufferEvent.CursorMovedTo CellGrid.originCell :> Message)
+        |> shouldEqual (fiveLineBuffer, BufferEvent.CursorMoved({ Column = 0<mColumn>; Row = 4<mRow> }, CellGrid.originCell) :> Message)

--- a/src/Void.Core.Spec/BufferSpec.fs
+++ b/src/Void.Core.Spec/BufferSpec.fs
@@ -6,63 +6,68 @@ open FsUnit
 
 [<TestFixture>]
 type ``Moving the cursor in a buffer``() = 
-    let h = Move.Backward 1<mCharacter> :> Motion |> BufferCommand.MoveCursor
-    let j = Move.Forward 1<mLine> :> Motion |> BufferCommand.MoveCursor
-    let k = Move.Backward 1<mLine> :> Motion |> BufferCommand.MoveCursor
-    let l = Move.Forward 1<mCharacter> :> Motion |> BufferCommand.MoveCursor
+    let h = Move.Backward 1<mColumn> |> MoveCursor
+    let j = Move.Forward 1<mRow> |> MoveCursor
+    let k = Move.Backward 1<mRow> |> MoveCursor
+    let l = Move.Forward 1<mColumn> |> MoveCursor
 
     let oneLineBuffer = Buffer.prepend Buffer.emptyFile "line 1"
     let twoLineBuffer = Buffer.prepend oneLineBuffer "line 2"
     let oneCharacterBuffer = Buffer.prepend Buffer.emptyFile "1"
 
+    let shouldEqual expected actual =
+        printfn "Expected: %A" expected
+        printfn "Actual: %A" actual
+        should equal expected actual
+
     [<Test>]
     member x.``down one line should do nothing in an empty buffer``() =
-        Buffer.handleCommand Buffer.emptyFile j
+        Buffer.handleMoveCursorByRows Buffer.emptyFile j
         |> should equal (Buffer.emptyFile, noMessage)
 
     [<Test>]
     member x.``up one line should do nothing in an empty buffer``() =
-        Buffer.handleCommand Buffer.emptyFile k
+        Buffer.handleMoveCursorByRows Buffer.emptyFile k
         |> should equal (Buffer.emptyFile, noMessage)
 
     [<Test>]
     member x.``backward one character should do nothing in an empty buffer``() =
-        Buffer.handleCommand Buffer.emptyFile h
+        Buffer.handleMoveCursorByColumns Buffer.emptyFile h
         |> should equal (Buffer.emptyFile, noMessage)
 
     [<Test>]
     member x.``forward one character should do nothing in an empty buffer``() =
-        Buffer.handleCommand Buffer.emptyFile l
+        Buffer.handleMoveCursorByColumns Buffer.emptyFile l
         |> should equal (Buffer.emptyFile, noMessage)
 
     [<Test>]
     member x.``down one line should do nothing in a buffer with only one line``() =
-        Buffer.handleCommand oneLineBuffer j
+        Buffer.handleMoveCursorByRows oneLineBuffer j
         |> should equal (oneLineBuffer, noMessage)
 
     [<Test>]
     member x.``up one line should do nothing in a buffer with only one line``() =
-        Buffer.handleCommand oneLineBuffer k
+        Buffer.handleMoveCursorByRows oneLineBuffer k
         |> should equal (oneLineBuffer, noMessage)
 
     [<Test>]
     member x.``backward one character should do nothing in a one-character buffer``() =
-        Buffer.handleCommand oneCharacterBuffer h
+        Buffer.handleMoveCursorByColumns oneCharacterBuffer h
         |> should equal (oneCharacterBuffer, noMessage)
 
     [<Test>]
     member x.``forward one character should do nothing in a one-character buffer``() =
-        Buffer.handleCommand oneCharacterBuffer l
+        Buffer.handleMoveCursorByColumns oneCharacterBuffer l
         |> should equal (oneCharacterBuffer, noMessage)
 
-    (*[<Test>]
-    member x.``down one line should succeed in a two-line buffer``() =
-        Buffer.handleCommand twoLineBuffer j
+    [<Test>]
+    member x.``down one line should succeed within a two-line buffer``() =
+        Buffer.handleMoveCursorByRows twoLineBuffer j
         |> snd
-        |> should equal (BufferEvent.CursorMovedTo { Column = 1; Row = 2 })
+        |> should equal (BufferEvent.CursorMovedTo { Column = 0<mColumn>; Row = 1<mRow> })
 
     [<Test>]
     member x.``moving up one line should undo moving down one line``() =
-        let moved = Buffer.handleCommand twoLineBuffer j |> fst
-        Buffer.handleCommand moved k
-        |> should equal (twoLineBuffer, BufferEvent.CursorMovedTo { Column = 1; Row = 2} )*)
+        let moved = Buffer.handleMoveCursorByRows twoLineBuffer j |> fst
+        Buffer.handleMoveCursorByRows moved k
+        |> shouldEqual (twoLineBuffer, BufferEvent.CursorMovedTo CellGrid.originCell :> Message)

--- a/src/Void.Core.Spec/BufferSpec.fs
+++ b/src/Void.Core.Spec/BufferSpec.fs
@@ -6,15 +6,15 @@ open FsUnit
 
 [<TestFixture>]
 type ``Moving the cursor in a buffer``() = 
-    let h = Move.Backward 1<mColumn> |> MoveCursor
-    let j = Move.Forward 1<mRow> |> MoveCursor
-    let k = Move.Backward 1<mRow> |> MoveCursor
-    let l = Move.Forward 1<mColumn> |> MoveCursor
+    let h = Move.backward By.column 1 |> MoveCursor
+    let j = Move.forward By.row 1 |> MoveCursor
+    let k = Move.backward By.row 1 |> MoveCursor
+    let l = Move.forward By.column 1 |> MoveCursor
 
-    let ``3j`` = Move.Forward 3<mRow> |> MoveCursor
-    let ``3k`` = Move.Backward 3<mRow> |> MoveCursor
-    let ``5j`` = Move.Forward 5<mRow> |> MoveCursor
-    let ``5k`` = Move.Backward 5<mRow> |> MoveCursor
+    let ``3j`` = Move.forward By.row 3 |> MoveCursor
+    let ``3k`` = Move.backward By.row 3 |> MoveCursor
+    let ``5j`` = Move.forward By.row 5 |> MoveCursor
+    let ``5k`` = Move.backward By.row 5 |> MoveCursor
 
     let oneLineBuffer = Buffer.prepend Buffer.emptyFile "line 1"
     let twoLineBuffer = Buffer.prepend oneLineBuffer "line 2"
@@ -31,75 +31,75 @@ type ``Moving the cursor in a buffer``() =
     [<Test>]
     member x.``down one line should do nothing in an empty buffer``() =
         Buffer.handleMoveCursorByRows Buffer.emptyFile j
-        |> should equal (Buffer.emptyFile, noMessage)
+        |> should equal (Buffer.emptyFile, Buffer.DidNotMove)
 
     [<Test>]
     member x.``up one line should do nothing in an empty buffer``() =
         Buffer.handleMoveCursorByRows Buffer.emptyFile k
-        |> should equal (Buffer.emptyFile, noMessage)
+        |> should equal (Buffer.emptyFile, Buffer.DidNotMove)
 
     [<Test>]
     member x.``backward one character should do nothing in an empty buffer``() =
         Buffer.handleMoveCursorByColumns Buffer.emptyFile h
-        |> should equal (Buffer.emptyFile, noMessage)
+        |> should equal (Buffer.emptyFile, Buffer.DidNotMove)
 
     [<Test>]
     member x.``forward one character should do nothing in an empty buffer``() =
         Buffer.handleMoveCursorByColumns Buffer.emptyFile l
-        |> should equal (Buffer.emptyFile, noMessage)
+        |> should equal (Buffer.emptyFile, Buffer.DidNotMove)
 
     [<Test>]
     member x.``down one line should do nothing in a buffer with only one line``() =
         Buffer.handleMoveCursorByRows oneLineBuffer j
-        |> should equal (oneLineBuffer, noMessage)
+        |> should equal (oneLineBuffer, Buffer.DidNotMove)
 
     [<Test>]
     member x.``up one line should do nothing in a buffer with only one line``() =
         Buffer.handleMoveCursorByRows oneLineBuffer k
-        |> should equal (oneLineBuffer, noMessage)
+        |> should equal (oneLineBuffer, Buffer.DidNotMove)
 
     [<Test>]
     member x.``backward one character should do nothing in a one-character buffer``() =
         Buffer.handleMoveCursorByColumns oneCharacterBuffer h
-        |> should equal (oneCharacterBuffer, noMessage)
+        |> should equal (oneCharacterBuffer, Buffer.DidNotMove)
 
     [<Test>]
     member x.``forward one character should do nothing in a one-character buffer``() =
         Buffer.handleMoveCursorByColumns oneCharacterBuffer l
-        |> should equal (oneCharacterBuffer, noMessage)
+        |> should equal (oneCharacterBuffer, Buffer.DidNotMove)
 
     [<Test>]
     member x.``down one line should succeed within a two-line buffer``() =
         Buffer.handleMoveCursorByRows twoLineBuffer j
         |> snd
-        |> should equal (BufferEvent.CursorMoved(CellGrid.originCell, { Column = 0<mColumn>; Row = 1<mRow> }))
+        |> should equal (Buffer.CursorMoved(CellGrid.originCell, { Column = 0<mColumn>; Row = 1<mRow> }))
 
     [<Test>]
     member x.``moving up one line should undo moving down one line``() =
         let moved = Buffer.handleMoveCursorByRows twoLineBuffer j |> fst
         Buffer.handleMoveCursorByRows moved k
-        |> shouldEqual (twoLineBuffer, BufferEvent.CursorMoved({ Column = 0<mColumn>; Row = 1<mRow> }, CellGrid.originCell) :> Message)
+        |> shouldEqual (twoLineBuffer, Buffer.CursorMoved({ Column = 0<mColumn>; Row = 1<mRow> }, CellGrid.originCell))
 
     [<Test>]
     member x.``down three lines should succeed within a five-line buffer``() =
         Buffer.handleMoveCursorByRows fiveLineBuffer ``3j``
         |> snd
-        |> should equal (BufferEvent.CursorMoved(CellGrid.originCell, { Column = 0<mColumn>; Row = 3<mRow> }))
+        |> should equal (Buffer.CursorMoved(CellGrid.originCell, { Column = 0<mColumn>; Row = 3<mRow> }))
 
     [<Test>]
     member x.``moving up three lines should undo moving down three lines``() =
         let moved = Buffer.handleMoveCursorByRows fiveLineBuffer ``3j`` |> fst
         Buffer.handleMoveCursorByRows moved ``3k``
-        |> shouldEqual (fiveLineBuffer, BufferEvent.CursorMoved({ Column = 0<mColumn>; Row = 3<mRow> }, CellGrid.originCell) :> Message)
+        |> shouldEqual (fiveLineBuffer, Buffer.CursorMoved({ Column = 0<mColumn>; Row = 3<mRow> }, CellGrid.originCell))
 
     [<Test>]
     member x.``trying to move down five lines within a five-line buffer should not overshoot``() =
         Buffer.handleMoveCursorByRows fiveLineBuffer ``5j``
         |> snd
-        |> shouldEqual (BufferEvent.CursorMoved(CellGrid.originCell, { Column = 0<mColumn>; Row = 4<mRow> }))
+        |> shouldEqual (Buffer.CursorMoved(CellGrid.originCell, { Column = 0<mColumn>; Row = 4<mRow> }))
 
     [<Test>]
     member x.``moving up five lines in a five-line buffer from the bottom should not overshoot``() =
         let moved = Buffer.handleMoveCursorByRows fiveLineBuffer ``5j`` |> fst
         Buffer.handleMoveCursorByRows moved ``5k``
-        |> shouldEqual (fiveLineBuffer, BufferEvent.CursorMoved({ Column = 0<mColumn>; Row = 4<mRow> }, CellGrid.originCell) :> Message)
+        |> shouldEqual (fiveLineBuffer, Buffer.CursorMoved({ Column = 0<mColumn>; Row = 4<mRow> }, CellGrid.originCell))

--- a/src/Void.Core.Spec/BufferSpec.fs
+++ b/src/Void.Core.Spec/BufferSpec.fs
@@ -1,0 +1,32 @@
+﻿namespace Void.Core.Spec
+
+open Void.Core
+open NUnit.Framework
+open FsUnit
+
+[<TestFixture>]
+type ``Moving the cursor in a buffer``() = 
+    let h = Move.Backward 1<mCharacter> :> Motion |> BufferCommand.MoveCursor
+    let j = Move.Forward 1<mLine> :> Motion |> BufferCommand.MoveCursor
+    let k = Move.Backward 1<mLine> :> Motion |> BufferCommand.MoveCursor
+    let l = Move.Forward 1<mCharacter> :> Motion |> BufferCommand.MoveCursor
+
+    [<Test>]
+    member x.``down one line should do nothing in an empty buffer``() =
+        Buffer.handleCommand Buffer.emptyFile j
+        |> should equal (Buffer.emptyFile, noMessage)
+
+    [<Test>]
+    member x.``up one line should do nothing in an empty buffer``() =
+        Buffer.handleCommand Buffer.emptyFile k
+        |> should equal (Buffer.emptyFile, noMessage)
+
+    [<Test>]
+    member x.``backward one character should do nothing in an empty buffer``() =
+        Buffer.handleCommand Buffer.emptyFile h
+        |> should equal (Buffer.emptyFile, noMessage)
+
+    [<Test>]
+    member x.``forward one character should do nothing in an empty buffer``() =
+        Buffer.handleCommand Buffer.emptyFile l
+        |> should equal (Buffer.emptyFile, noMessage)

--- a/src/Void.Core.Spec/BufferSpec.fs
+++ b/src/Void.Core.Spec/BufferSpec.fs
@@ -11,8 +11,9 @@ type ``Moving the cursor in a buffer``() =
     let k = Move.Backward 1<mLine> :> Motion |> BufferCommand.MoveCursor
     let l = Move.Forward 1<mCharacter> :> Motion |> BufferCommand.MoveCursor
 
-    let oneLineBuffer = Buffer.prepend Buffer.emptyFile "foobar"
-    let oneCharacterBuffer = Buffer.prepend Buffer.emptyFile "o"
+    let oneLineBuffer = Buffer.prepend Buffer.emptyFile "line 1"
+    let twoLineBuffer = Buffer.prepend oneLineBuffer "line 2"
+    let oneCharacterBuffer = Buffer.prepend Buffer.emptyFile "1"
 
     [<Test>]
     member x.``down one line should do nothing in an empty buffer``() =
@@ -53,3 +54,15 @@ type ``Moving the cursor in a buffer``() =
     member x.``forward one character should do nothing in a one-character buffer``() =
         Buffer.handleCommand oneCharacterBuffer l
         |> should equal (oneCharacterBuffer, noMessage)
+
+    (*[<Test>]
+    member x.``down one line should succeed in a two-line buffer``() =
+        Buffer.handleCommand twoLineBuffer j
+        |> snd
+        |> should equal (BufferEvent.CursorMovedTo { Column = 1; Row = 2 })
+
+    [<Test>]
+    member x.``moving up one line should undo moving down one line``() =
+        let moved = Buffer.handleCommand twoLineBuffer j |> fst
+        Buffer.handleCommand moved k
+        |> should equal (twoLineBuffer, BufferEvent.CursorMovedTo { Column = 1; Row = 2} )*)

--- a/src/Void.Core.Spec/BufferSpec.fs
+++ b/src/Void.Core.Spec/BufferSpec.fs
@@ -11,6 +11,9 @@ type ``Moving the cursor in a buffer``() =
     let k = Move.Backward 1<mLine> :> Motion |> BufferCommand.MoveCursor
     let l = Move.Forward 1<mCharacter> :> Motion |> BufferCommand.MoveCursor
 
+    let oneLineBuffer = Buffer.prepend Buffer.emptyFile "foobar"
+    let oneCharacterBuffer = Buffer.prepend Buffer.emptyFile "o"
+
     [<Test>]
     member x.``down one line should do nothing in an empty buffer``() =
         Buffer.handleCommand Buffer.emptyFile j
@@ -30,3 +33,23 @@ type ``Moving the cursor in a buffer``() =
     member x.``forward one character should do nothing in an empty buffer``() =
         Buffer.handleCommand Buffer.emptyFile l
         |> should equal (Buffer.emptyFile, noMessage)
+
+    [<Test>]
+    member x.``down one line should do nothing in a buffer with only one line``() =
+        Buffer.handleCommand oneLineBuffer j
+        |> should equal (oneLineBuffer, noMessage)
+
+    [<Test>]
+    member x.``up one line should do nothing in a buffer with only one line``() =
+        Buffer.handleCommand oneLineBuffer k
+        |> should equal (oneLineBuffer, noMessage)
+
+    [<Test>]
+    member x.``backward one character should do nothing in a one-character buffer``() =
+        Buffer.handleCommand oneCharacterBuffer h
+        |> should equal (oneCharacterBuffer, noMessage)
+
+    [<Test>]
+    member x.``forward one character should do nothing in a one-character buffer``() =
+        Buffer.handleCommand oneCharacterBuffer l
+        |> should equal (oneCharacterBuffer, noMessage)

--- a/src/Void.Core.Spec/BufferSpec.fs
+++ b/src/Void.Core.Spec/BufferSpec.fs
@@ -69,10 +69,16 @@ type ``Moving the cursor in a buffer``() =
         |> should equal (oneCharacterBuffer, Buffer.DidNotMove)
 
     [<Test>]
-    member x.``down one line should succeed within a two-line buffer``() =
+    member x.``down one line should succeed within a two-line buffer when starting on line one``() =
         Buffer.handleMoveCursorByRows twoLineBuffer j
         |> snd
         |> should equal (Buffer.CursorMoved(CellGrid.originCell, { Column = 0<mColumn>; Row = 1<mRow> }))
+
+    [<Test>]
+    member x.``down one line should do nothing within a two-line buffer when starting on line two``() =
+        let onLineTwo, _ = Buffer.handleMoveCursorByRows twoLineBuffer j
+        Buffer.handleMoveCursorByRows onLineTwo j
+        |> should equal (onLineTwo, Buffer.DidNotMove)
 
     [<Test>]
     member x.``moving up one line should undo moving down one line``() =

--- a/src/Void.Core.Spec/BufferSpec.fs
+++ b/src/Void.Core.Spec/BufferSpec.fs
@@ -23,11 +23,6 @@ type ``Moving the cursor in a buffer``() =
         |> Buffer.loadContents Buffer.emptyFile
     let oneCharacterBuffer = Buffer.prepend Buffer.emptyFile "1"
 
-    let shouldEqual expected actual =
-        printfn "Expected: %A" expected
-        printfn "Actual: %A" actual
-        should equal expected actual
-
     [<Test>]
     member x.``down one line should do nothing in an empty buffer``() =
         Buffer.handleMoveCursorByRows Buffer.emptyFile j
@@ -84,7 +79,7 @@ type ``Moving the cursor in a buffer``() =
     member x.``moving up one line should undo moving down one line``() =
         let moved = Buffer.handleMoveCursorByRows twoLineBuffer j |> fst
         Buffer.handleMoveCursorByRows moved k
-        |> shouldEqual (twoLineBuffer, Buffer.CursorMoved({ Column = 0<mColumn>; Row = 1<mRow> }, CellGrid.originCell))
+        |> should equal (twoLineBuffer, Buffer.CursorMoved({ Column = 0<mColumn>; Row = 1<mRow> }, CellGrid.originCell))
 
     [<Test>]
     member x.``down three lines should succeed within a five-line buffer``() =
@@ -96,16 +91,16 @@ type ``Moving the cursor in a buffer``() =
     member x.``moving up three lines should undo moving down three lines``() =
         let moved = Buffer.handleMoveCursorByRows fiveLineBuffer ``3j`` |> fst
         Buffer.handleMoveCursorByRows moved ``3k``
-        |> shouldEqual (fiveLineBuffer, Buffer.CursorMoved({ Column = 0<mColumn>; Row = 3<mRow> }, CellGrid.originCell))
+        |> should equal (fiveLineBuffer, Buffer.CursorMoved({ Column = 0<mColumn>; Row = 3<mRow> }, CellGrid.originCell))
 
     [<Test>]
     member x.``trying to move down five lines within a five-line buffer should not overshoot``() =
         Buffer.handleMoveCursorByRows fiveLineBuffer ``5j``
         |> snd
-        |> shouldEqual (Buffer.CursorMoved(CellGrid.originCell, { Column = 0<mColumn>; Row = 4<mRow> }))
+        |> should equal (Buffer.CursorMoved(CellGrid.originCell, { Column = 0<mColumn>; Row = 4<mRow> }))
 
     [<Test>]
     member x.``moving up five lines in a five-line buffer from the bottom should not overshoot``() =
         let moved = Buffer.handleMoveCursorByRows fiveLineBuffer ``5j`` |> fst
         Buffer.handleMoveCursorByRows moved ``5k``
-        |> shouldEqual (fiveLineBuffer, Buffer.CursorMoved({ Column = 0<mColumn>; Row = 4<mRow> }, CellGrid.originCell))
+        |> should equal (fiveLineBuffer, Buffer.CursorMoved({ Column = 0<mColumn>; Row = 4<mRow> }, CellGrid.originCell))

--- a/src/Void.Core.Spec/NormalModeSpec.fs
+++ b/src/Void.Core.Spec/NormalModeSpec.fs
@@ -39,56 +39,51 @@ type ``Parsing normal mode commands``() =
     let q =
         { Key = KeyPress.Q; Timestamp = startTime }
 
-    let shouldEqual expected actual =
-        printfn "Expected: %A" expected
-        printfn "Actual: %A" actual
-        should equal expected actual
-
     [<Test>]
     member x.``Hitting escape clears any previous keys``() =
         let state = { startState with KeyPressBuffer = [KeyPress.Q; KeyPress.G] }
         handleKeyPress state escape
-        |> shouldEqual (startState, Event.KeyPressesCleared :> Message)
+        |> should equal (startState, Event.KeyPressesCleared :> Message)
 
     [<Test>]
     member x.``After receiving a single key press should translate it into a command``() =
         handleKeyPress startState semicolon
-        |> shouldEqual (startState, CoreCommand.ChangeToMode Mode.Command :> Message)
+        |> should equal (startState, CoreCommand.ChangeToMode Mode.Command :> Message)
 
     [<Test>]
     member x.``After receiving a key press with no match should be waiting another key press``() =
         handleKeyPress startState shiftZ
-        |> shouldEqual ({ laterState with KeyPressBuffer = [KeyPress.ShiftZ]}, Event.KeyPressRegistered KeyPress.ShiftZ :> Message)
+        |> should equal ({ laterState with KeyPressBuffer = [KeyPress.ShiftZ]}, Event.KeyPressRegistered KeyPress.ShiftZ :> Message)
 
     [<Test>]
     member x.``After receiving a two key press with no match should be waiting for a third key press``() =
         let state = { startState with KeyPressBuffer = [KeyPress.ShiftG] }
         handleKeyPress state shiftQ
-        |> shouldEqual ({ laterState with KeyPressBuffer = [KeyPress.ShiftQ; KeyPress.ShiftG]}, Event.KeyPressRegistered KeyPress.ShiftQ :> Message)
+        |> should equal ({ laterState with KeyPressBuffer = [KeyPress.ShiftQ; KeyPress.ShiftG]}, Event.KeyPressRegistered KeyPress.ShiftQ :> Message)
 
     [<Test>]
     member x.``After receiving two key presses that together match should translate them into a command``() =
         let state = { startState with KeyPressBuffer = [KeyPress.ShiftZ] }
         handleKeyPress state shiftQ
-        |> shouldEqual (startState, CoreCommand.QuitWithoutSaving :> Message)
+        |> should equal (startState, CoreCommand.QuitWithoutSaving :> Message)
 
     [<Test>]
     member x.``After receiving three key presses that together match should translate them into a command``() =
         let state = { startState with KeyPressBuffer = [KeyPress.Q; KeyPress.G] }
         handleKeyPress state q
-        |> shouldEqual (startState, CoreCommand.FormatCurrentLine :> Message)
+        |> should equal (startState, CoreCommand.FormatCurrentLine :> Message)
 
     [<Test>]
     member x.``After receiving two key presses less than the timeout period apart should translate them into a command``() =
         let state = { startState with KeyPressBuffer = [KeyPress.ShiftZ] }
         handleKeyPress state { shiftQ with Timestamp = ``less than a second later`` }
-        |> shouldEqual (startState, CoreCommand.QuitWithoutSaving :> Message)
+        |> should equal (startState, CoreCommand.QuitWithoutSaving :> Message)
 
     [<Test>]
     member x.``After receiving two key presses more than the timeout period apart should throw the first away``() =
         let state = { laterState with KeyPressBuffer = [KeyPress.ShiftZ] }
         handleKeyPress state { shiftQ with Timestamp = ``more than a second later`` }
-        |> shouldEqual (
+        |> should equal (
             {
                 Bindings = bindingsForTest
                 KeyPressBuffer = [KeyPress.ShiftQ]
@@ -99,4 +94,4 @@ type ``Parsing normal mode commands``() =
     member x.``After receiving two key presses more than the timeout period apart should match the second one in isolation if necessary``() =
         let state = { laterState with KeyPressBuffer = [KeyPress.ShiftZ] }
         handleKeyPress state { semicolon with Timestamp = ``more than a second later`` }
-        |> shouldEqual (startState, CoreCommand.ChangeToMode Mode.Command :> Message)
+        |> should equal (startState, CoreCommand.ChangeToMode Mode.Command :> Message)

--- a/src/Void.Core.Spec/Void.Core.Spec.fsproj
+++ b/src/Void.Core.Spec/Void.Core.Spec.fsproj
@@ -64,11 +64,15 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FsUnit.NUnit">
-      <HintPath>..\packages\FsUnit.1.3.0.1\Lib\Net40\FsUnit.NUnit.dll</HintPath>
+      <HintPath>..\packages\FsUnit.1.4.0.0-beta\lib\FsUnit.NUnit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NHamcrest">
+      <HintPath>..\packages\FsUnit.1.4.0.0-beta\lib\NHamcrest.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">

--- a/src/Void.Core.Spec/Void.Core.Spec.fsproj
+++ b/src/Void.Core.Spec/Void.Core.Spec.fsproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\Void.Core.Spec.XML</DocumentationFile>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\Void.Core.Spec.XML</DocumentationFile>

--- a/src/Void.Core.Spec/Void.Core.Spec.fsproj
+++ b/src/Void.Core.Spec/Void.Core.Spec.fsproj
@@ -60,6 +60,7 @@
     <Compile Include="NormalModeSpec.fs" />
     <Compile Include="CommandModeSpec.fs" />
     <Compile Include="CommandHistorySpec.fs" />
+    <Compile Include="BufferSpec.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FsUnit.NUnit">

--- a/src/Void.Core.Spec/packages.config
+++ b/src/Void.Core.Spec/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FsUnit" version="1.3.0.1" targetFramework="net45" />
+  <package id="FsUnit" version="1.4.0.0-beta" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/Void.Core/Buffer.fs
+++ b/src/Void.Core/Buffer.fs
@@ -49,10 +49,11 @@ module Buffer =
                 { buffer with CursorPosition = newPosition }, event
             else buffer, DidNotMove
         | MoveCursor (Move.Forward (By.Row rows)) ->
+            let rowsToTheEnd = lengthInRows buffer - buffer.CursorPosition.Row
             let rowsToMove =
-                if lengthInRows buffer > rows
+                if rowsToTheEnd > rows
                 then rows
-                else lengthInRows buffer - 1<mRow>
+                else rowsToTheEnd - 1<mRow>
             if rowsToMove > 0<mRow>
             then
                 let newPosition = below buffer.CursorPosition rowsToMove

--- a/src/Void.Core/Buffer.fs
+++ b/src/Void.Core/Buffer.fs
@@ -1,0 +1,69 @@
+﻿namespace Void.Core
+
+type FileBuffer = private {
+    // TODO This is naive, obviously
+    Filepath : string option
+    Contents : string list
+    CursorPosition : CellGrid.Cell
+}
+
+module Buffer =
+    open CellGrid
+
+    let lengthInRows (buffer : FileBuffer) =
+        buffer.Contents.Length * 1<mRow>
+
+    let emptyFile =
+        { Filepath = None; Contents = []; CursorPosition = originCell }
+
+    let loadContents (buffer : FileBuffer) contents =
+        { buffer with Contents = contents }
+
+    let prepend (buffer : FileBuffer) line =
+        { buffer with Contents = line :: buffer.Contents }
+
+    let newFile path =
+        { Filepath = Some path; Contents = []; CursorPosition = originCell }
+
+    let existingFile path contents =
+        { Filepath = Some path; Contents = contents; CursorPosition = originCell }
+
+    let readLines fileBuffer start =
+        fileBuffer.Contents |> Seq.skip ((start - 1<mLine>)/1<mLine>) // Line numbers start at 1
+
+    type CursorEvent =
+        | DidNotMove
+        | CursorMoved of From : Cell * To : Cell
+
+    let handleMoveCursorByRows buffer (moveCursor : MoveCursor<mRow>) =
+        match moveCursor with
+        | MoveCursor (Move.Backward rows) ->
+            let rowsToMove =
+                if buffer.CursorPosition.Row >= rows
+                then rows
+                else buffer.CursorPosition.Row
+            if rowsToMove > 0<mRow>
+            then
+                let newPosition = above buffer.CursorPosition rowsToMove
+                let event = CursorMoved(buffer.CursorPosition, newPosition)
+                { buffer with CursorPosition = newPosition }, event
+            else buffer, DidNotMove
+        | MoveCursor (Move.Forward rows) ->
+            let rowsToMove =
+                if lengthInRows buffer > rows
+                then rows
+                else lengthInRows buffer - 1<mRow>
+            if rowsToMove > 0<mRow>
+            then
+                let newPosition = below buffer.CursorPosition rowsToMove
+                let event = CursorMoved(buffer.CursorPosition, newPosition)
+                { buffer with CursorPosition = newPosition }, event
+            else buffer, DidNotMove
+
+    let handleMoveCursorByColumns buffer (moveCursor : MoveCursor<mColumn>) =
+        match moveCursor with
+        | MoveCursor (Move.Backward columns) ->
+            buffer, DidNotMove
+        | MoveCursor (Move.Forward columns) ->
+            buffer, DidNotMove
+

--- a/src/Void.Core/Buffer.fs
+++ b/src/Void.Core/Buffer.fs
@@ -35,9 +35,9 @@ module Buffer =
         | DidNotMove
         | CursorMoved of From : Cell * To : Cell
 
-    let handleMoveCursorByRows buffer (moveCursor : MoveCursor<ByRow, mRow>) =
+    let handleMoveCursorByRows buffer (moveCursor : MoveCursor<By.Row>) =
         match moveCursor with
-        | MoveCursor (Move.Backward rows) ->
+        | MoveCursor (Move.Backward (By.Row rows)) ->
             let rowsToMove =
                 if buffer.CursorPosition.Row >= rows
                 then rows
@@ -48,7 +48,7 @@ module Buffer =
                 let event = CursorMoved(buffer.CursorPosition, newPosition)
                 { buffer with CursorPosition = newPosition }, event
             else buffer, DidNotMove
-        | MoveCursor (Move.Forward rows) ->
+        | MoveCursor (Move.Forward (By.Row rows)) ->
             let rowsToMove =
                 if lengthInRows buffer > rows
                 then rows
@@ -60,10 +60,10 @@ module Buffer =
                 { buffer with CursorPosition = newPosition }, event
             else buffer, DidNotMove
 
-    let handleMoveCursorByColumns buffer (moveCursor : MoveCursor<ByColumn, mColumn>) =
+    let handleMoveCursorByColumns buffer (moveCursor : MoveCursor<By.Column>) =
         match moveCursor with
-        | MoveCursor (Move.Backward columns) ->
+        | MoveCursor (Move.Backward (By.Column columns)) ->
             buffer, DidNotMove
-        | MoveCursor (Move.Forward columns) ->
+        | MoveCursor (Move.Forward (By.Column columns)) ->
             buffer, DidNotMove
 

--- a/src/Void.Core/Buffer.fs
+++ b/src/Void.Core/Buffer.fs
@@ -35,7 +35,7 @@ module Buffer =
         | DidNotMove
         | CursorMoved of From : Cell * To : Cell
 
-    let handleMoveCursorByRows buffer (moveCursor : MoveCursor<mRow>) =
+    let handleMoveCursorByRows buffer (moveCursor : MoveCursor<ByRow, mRow>) =
         match moveCursor with
         | MoveCursor (Move.Backward rows) ->
             let rowsToMove =
@@ -60,7 +60,7 @@ module Buffer =
                 { buffer with CursorPosition = newPosition }, event
             else buffer, DidNotMove
 
-    let handleMoveCursorByColumns buffer (moveCursor : MoveCursor<mColumn>) =
+    let handleMoveCursorByColumns buffer (moveCursor : MoveCursor<ByColumn, mColumn>) =
         match moveCursor with
         | MoveCursor (Move.Backward columns) ->
             buffer, DidNotMove

--- a/src/Void.Core/BufferList.fs
+++ b/src/Void.Core/BufferList.fs
@@ -1,7 +1,7 @@
 ﻿namespace Void.Core
 
-// TODO This is naive, obviously
 type FileBuffer = private {
+    // TODO This is naive, obviously
     Filepath : string option
     Contents : string list
     CursorPosition : CellGrid.Cell
@@ -25,8 +25,27 @@ module Buffer =
     let readLines fileBuffer start =
         fileBuffer.Contents |> Seq.skip ((start - 1<mLine>)/1<mLine>) // Line numbers start at 1
 
-    let handleCommand buffer (BufferCommand.MoveCursor motion) =
-        buffer, noMessage
+    let handleMoveCursorByRows buffer (moveCursor : MoveCursor<mRow>) =
+        match moveCursor with
+        | MoveCursor (Move.Backward rows) ->
+            if buffer.Contents.Length > 1
+            then
+                let newPosition = above buffer.CursorPosition rows
+                { buffer with CursorPosition = newPosition }, BufferEvent.CursorMovedTo newPosition :> Message
+            else buffer, noMessage
+        | MoveCursor (Move.Forward rows) ->
+            if buffer.Contents.Length > 1
+            then
+                let newPosition = below buffer.CursorPosition rows
+                { buffer with CursorPosition = newPosition }, BufferEvent.CursorMovedTo newPosition :> Message
+            else buffer, noMessage
+
+    let handleMoveCursorByColumns buffer (moveCursor : MoveCursor<mColumn>) =
+        match moveCursor with
+        | MoveCursor (Move.Backward columns) ->
+            buffer, noMessage
+        | MoveCursor (Move.Forward columns) ->
+            buffer, noMessage
 
 type Buffers = private {
     List : Map<int, FileBuffer>

--- a/src/Void.Core/BufferList.fs
+++ b/src/Void.Core/BufferList.fs
@@ -13,6 +13,9 @@ module Buffer =
     let emptyFile =
         { Filepath = None; Contents = []; CursorPosition = originCell }
 
+    let prepend (buffer : FileBuffer) line =
+        { buffer with Contents = line :: buffer.Contents }
+
     let newFile path =
         { Filepath = Some path; Contents = []; CursorPosition = originCell }
 

--- a/src/Void.Core/BufferList.fs
+++ b/src/Void.Core/BufferList.fs
@@ -22,6 +22,9 @@ module Buffer =
     let readLines fileBuffer start =
         fileBuffer.Contents |> Seq.skip ((start - 1<mLine>)/1<mLine>) // Line numbers start at 1
 
+    let handleCommand buffer (BufferCommand.MoveCursor motion) =
+        buffer, noMessage
+
 type Buffers = private {
     List : Map<int, FileBuffer>
     LastId : int

--- a/src/Void.Core/BufferList.fs
+++ b/src/Void.Core/BufferList.fs
@@ -10,8 +10,14 @@ type FileBuffer = private {
 module Buffer =
     open CellGrid
 
+    let lengthInRows (buffer : FileBuffer) =
+        buffer.Contents.Length * 1<mRow>
+
     let emptyFile =
         { Filepath = None; Contents = []; CursorPosition = originCell }
+
+    let loadContents (buffer : FileBuffer) contents =
+        { buffer with Contents = contents }
 
     let prepend (buffer : FileBuffer) line =
         { buffer with Contents = line :: buffer.Contents }
@@ -28,15 +34,23 @@ module Buffer =
     let handleMoveCursorByRows buffer (moveCursor : MoveCursor<mRow>) =
         match moveCursor with
         | MoveCursor (Move.Backward rows) ->
-            if buffer.Contents.Length > 1
+            let rowsToMove =
+                if buffer.CursorPosition.Row >= rows
+                then rows
+                else buffer.CursorPosition.Row
+            if rowsToMove > 0<mRow>
             then
-                let newPosition = above buffer.CursorPosition rows
+                let newPosition = above buffer.CursorPosition rowsToMove
                 { buffer with CursorPosition = newPosition }, BufferEvent.CursorMovedTo newPosition :> Message
             else buffer, noMessage
         | MoveCursor (Move.Forward rows) ->
-            if buffer.Contents.Length > 1
+            let rowsToMove =
+                if lengthInRows buffer > rows
+                then rows
+                else lengthInRows buffer - 1<mRow>
+            if rowsToMove > 0<mRow>
             then
-                let newPosition = below buffer.CursorPosition rows
+                let newPosition = below buffer.CursorPosition rowsToMove
                 { buffer with CursorPosition = newPosition }, BufferEvent.CursorMovedTo newPosition :> Message
             else buffer, noMessage
 

--- a/src/Void.Core/BufferMessages.fs
+++ b/src/Void.Core/BufferMessages.fs
@@ -23,6 +23,7 @@ type BufferCommand =
 [<RequireQualifiedAccess>]
 type BufferEvent =
     | Added of FileBufferProxy
+    | CursorMovedTo of CellGrid.Cell
     interface EventMessage
     interface BufferMessage
 

--- a/src/Void.Core/BufferMessages.fs
+++ b/src/Void.Core/BufferMessages.fs
@@ -14,9 +14,13 @@ type FileBufferProxy = {
     Contents : string seq
 }
 
-[<RequireQualifiedAccess>]
-type BufferCommand =
-    | MoveCursor of Motion
+type MoveCursor<[<Measure>]'UnitOfMotion> =
+    | MoveCursor of Move<'UnitOfMotion>
+    interface CommandMessage
+    interface BufferMessage
+
+type MoveCursorTo<[<Measure>]'InnerUnit, [<Measure>]'OuterUnit> =
+    | MoveCursorTo of MoveTo<'InnerUnit, 'OuterUnit>
     interface CommandMessage
     interface BufferMessage
 

--- a/src/Void.Core/BufferMessages.fs
+++ b/src/Void.Core/BufferMessages.fs
@@ -14,12 +14,12 @@ type FileBufferProxy = {
     Contents : string seq
 }
 
-type MoveCursor<'TBy, [<Measure>]'UnitOfMotion> =
-    | MoveCursor of Move<'UnitOfMotion>
+type MoveCursor<'By> =
+    | MoveCursor of Move<'By>
     interface CommandMessage
     interface BufferMessage
 
-type MoveCursorTo<'TBy, [<Measure>]'InnerUnit, [<Measure>]'OuterUnit> =
+type MoveCursorTo<[<Measure>]'InnerUnit, [<Measure>]'OuterUnit> =
     | MoveCursorTo of MoveTo<'InnerUnit, 'OuterUnit>
     interface CommandMessage
     interface BufferMessage

--- a/src/Void.Core/BufferMessages.fs
+++ b/src/Void.Core/BufferMessages.fs
@@ -14,12 +14,12 @@ type FileBufferProxy = {
     Contents : string seq
 }
 
-type MoveCursor<[<Measure>]'UnitOfMotion> =
+type MoveCursor<'TBy, [<Measure>]'UnitOfMotion> =
     | MoveCursor of Move<'UnitOfMotion>
     interface CommandMessage
     interface BufferMessage
 
-type MoveCursorTo<[<Measure>]'InnerUnit, [<Measure>]'OuterUnit> =
+type MoveCursorTo<'TBy, [<Measure>]'InnerUnit, [<Measure>]'OuterUnit> =
     | MoveCursorTo of MoveTo<'InnerUnit, 'OuterUnit>
     interface CommandMessage
     interface BufferMessage

--- a/src/Void.Core/BufferMessages.fs
+++ b/src/Void.Core/BufferMessages.fs
@@ -27,7 +27,7 @@ type MoveCursorTo<[<Measure>]'InnerUnit, [<Measure>]'OuterUnit> =
 [<RequireQualifiedAccess>]
 type BufferEvent =
     | Added of FileBufferProxy
-    | CursorMovedTo of CellGrid.Cell
+    | CursorMoved of From : CellGrid.Cell * To : CellGrid.Cell
     interface EventMessage
     interface BufferMessage
 

--- a/src/Void.Core/Grids.fs
+++ b/src/Void.Core/Grids.fs
@@ -18,19 +18,19 @@ module PointGrid =
 
 module CellGrid =
     type Cell = {
-        Row : int
-        Column : int
+        Row : int<mRow>
+        Column : int<mColumn>
     }
     type Dimensions = {
-        Rows : int
-        Columns : int
+        Rows : int<mRow>
+        Columns : int<mColumn>
     }
     type Block = {
         UpperLeftCell : Cell
         Dimensions : Dimensions
     }
-    let originCell = { Row = 0; Column = 0 }
-    let zeroDimensions = { Rows = 0; Columns = 0 }
+    let originCell = { Row = 0<mRow>; Column = 0<mColumn> }
+    let zeroDimensions = { Rows = 0<mRow>; Columns = 0<mColumn> }
     let zeroBlock = { UpperLeftCell = originCell; Dimensions = zeroDimensions }
 
     let rightOf cell count =
@@ -40,7 +40,7 @@ module CellGrid =
         { Row = cell.Row + count; Column = cell.Column }
 
     let lastRow block =
-        block.Dimensions.Rows - 1
+        block.Dimensions.Rows - 1<mRow>
 
     let lessRows n dimensions =
         { dimensions with Rows = dimensions.Rows - n }
@@ -59,10 +59,10 @@ module GridConvert =
     open CellGrid
 
     let upperLeftCornerOf cell =
-        { X = cell.Column; Y = cell.Row }
+        { X = cell.Column/1<mColumn>; Y = cell.Row/1<mRow> }
 
     let dimensionsInPoints dimensions =
-        { Width = dimensions.Columns; Height = dimensions.Rows }
+        { Width = dimensions.Columns/1<mColumn>; Height = dimensions.Rows/1<mRow> }
 
     let boxAround block =
         {

--- a/src/Void.Core/Grids.fs
+++ b/src/Void.Core/Grids.fs
@@ -36,8 +36,14 @@ module CellGrid =
     let rightOf cell count =
         { Row = cell.Row; Column = cell.Column + count }
 
+    let leftOf cell count =
+        { Row = cell.Row; Column = cell.Column - count }
+
     let below cell count =
         { Row = cell.Row + count; Column = cell.Column }
+
+    let above cell count =
+        { Row = cell.Row - count; Column = cell.Column }
 
     let lastRow block =
         block.Dimensions.Rows - 1<mRow>

--- a/src/Void.Core/Motion.fs
+++ b/src/Void.Core/Motion.fs
@@ -1,16 +1,12 @@
 ﻿namespace Void.Core
 
-type Motion = interface end
-
 [<RequireQualifiedAccess>]
 type Move<[<Measure>]'UnitOfMotion> = // Relative motion
     | Backward of int<'UnitOfMotion>
     | Forward of int<'UnitOfMotion>
-    interface Motion
 
 [<RequireQualifiedAccess>]
 type MoveTo<[<Measure>]'InnerUnit, [<Measure>]'OuterUnit> = // Absolute motion
     | First
     | Nth of int<'InnerUnit>
     | Last
-    interface Motion

--- a/src/Void.Core/Motion.fs
+++ b/src/Void.Core/Motion.fs
@@ -1,10 +1,5 @@
 ﻿namespace Void.Core
 
-[<Measure>] type mCharacter
-[<Measure>] type mLine
-[<Measure>] type mPararagraph
-[<Measure>] type mBuffer
-
 type Motion = interface end
 
 [<RequireQualifiedAccess>]

--- a/src/Void.Core/Motion.fs
+++ b/src/Void.Core/Motion.fs
@@ -1,9 +1,32 @@
 ﻿namespace Void.Core
 
+module By =
+    (* Unit of measure types seem to get erased at runtime.
+     * When we need a downcast to work, we need a type that doesn't get erased.
+     * Thus these By* types provide a wrapper. *)
+    type Column = Column of int<mColumn>
+    type Row = Row of int<mRow>
+    type Line = Line of int<mLine>
+
+    let row (x : int) =
+        Row (x*1<mRow>)
+
+    let column (x : int) =
+        Column (x*1<mColumn>)
+
+    let line (x : int) =
+        Line (x * 1<mLine>)
+
 [<RequireQualifiedAccess>]
-type Move<[<Measure>]'UnitOfMotion> = // Relative motion
-    | Backward of int<'UnitOfMotion>
-    | Forward of int<'UnitOfMotion>
+type Move<'By> = // Relative motion
+    | Backward of 'By
+    | Forward of 'By
+
+module Move =
+    let backward by x =
+        Move.Backward (by x)
+    let forward by x =
+        Move.Forward (by x)
 
 [<RequireQualifiedAccess>]
 type MoveTo<[<Measure>]'InnerUnit, [<Measure>]'OuterUnit> = // Absolute motion

--- a/src/Void.Core/Units.fs
+++ b/src/Void.Core/Units.fs
@@ -1,0 +1,22 @@
+﻿namespace Void.Core
+
+[<Measure>] type mCharacter
+[<Measure>] type mLine
+[<Measure>] type mPararagraph
+[<Measure>] type mBuffer
+
+[<Measure>] type mRow
+[<Measure>] type mColumn
+
+[<AutoOpen>]
+module UnitConversions =
+    let linePerRow = 1<mLine>/1<mRow>
+    let rowPerLine = 1/linePerRow
+
+    (* IMPORTANT!!! Lines are 1-based. Rows are 0-based. *)
+
+    let ``line#->row#`` ``line#`` =
+        ``line#`` * rowPerLine - 1<mRow>
+
+    let ``row#->line#`` ``row#`` =
+        ``row#`` * linePerRow + 1<mLine>

--- a/src/Void.Core/Units.fs
+++ b/src/Void.Core/Units.fs
@@ -20,3 +20,6 @@ module UnitConversions =
 
     let ``row#->line#`` ``row#`` =
         ``row#`` * linePerRow + 1<mLine>
+
+type ByRow = ByRow
+type ByColumn = ByColumn

--- a/src/Void.Core/Units.fs
+++ b/src/Void.Core/Units.fs
@@ -20,6 +20,3 @@ module UnitConversions =
 
     let ``row#->line#`` ``row#`` =
         ``row#`` * linePerRow + 1<mLine>
-
-type ByRow = ByRow
-type ByColumn = ByColumn

--- a/src/Void.Core/Void.Core.fsproj
+++ b/src/Void.Core/Void.Core.fsproj
@@ -21,7 +21,8 @@
     <OutputPath>../../build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\Void.Core.XML</DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>

--- a/src/Void.Core/Void.Core.fsproj
+++ b/src/Void.Core/Void.Core.fsproj
@@ -66,6 +66,7 @@
     <Compile Include="ModeService.fs" />
     <Compile Include="EditorService.fs" />
     <Compile Include="Filesystem.fs" />
+    <Compile Include="Buffer.fs" />
     <Compile Include="BufferList.fs" />
     <Compile Include="CommandHistory.fs" />
     <Compile Include="CommandLanguage.fs" />

--- a/src/Void.Core/Void.Core.fsproj
+++ b/src/Void.Core/Void.Core.fsproj
@@ -54,6 +54,7 @@
     <Compile Include="Keys.fs" />
     <Compile Include="UserNotificationTypes.fs" />
     <Compile Include="ModeTypes.fs" />
+    <Compile Include="Units.fs" />
     <Compile Include="Grids.fs" />
     <Compile Include="Motion.fs" />
     <Compile Include="CommandModeMessages.fs" />

--- a/src/Void.Core/Void.Core.fsproj
+++ b/src/Void.Core/Void.Core.fsproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\Void.Core.XML</DocumentationFile>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\Void.Core.XML</DocumentationFile>

--- a/src/Void.Lang.Editor/Void.Lang.Editor.fsproj
+++ b/src/Void.Lang.Editor/Void.Lang.Editor.fsproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\Void.Lang.Editor.XML</DocumentationFile>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\Void.Lang.Editor.XML</DocumentationFile>

--- a/src/Void.Lang.Interpreter.Spec/Void.Lang.Interpreter.Spec.fsproj
+++ b/src/Void.Lang.Interpreter.Spec/Void.Lang.Interpreter.Spec.fsproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\Void.Lang.Interpreter.Spec.XML</DocumentationFile>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\Void.Lang.Interpreter.Spec.XML</DocumentationFile>

--- a/src/Void.Lang.Interpreter.Spec/Void.Lang.Interpreter.Spec.fsproj
+++ b/src/Void.Lang.Interpreter.Spec/Void.Lang.Interpreter.Spec.fsproj
@@ -73,11 +73,15 @@
       <Private>True</Private>
     </ProjectReference>
     <Reference Include="FsUnit.NUnit">
-      <HintPath>..\packages\FsUnit.1.3.0.1\Lib\Net40\FsUnit.NUnit.dll</HintPath>
+      <HintPath>..\packages\FsUnit.1.4.0.0-beta\lib\FsUnit.NUnit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NHamcrest">
+      <HintPath>..\packages\FsUnit.1.4.0.0-beta\lib\NHamcrest.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">

--- a/src/Void.Lang.Interpreter.Spec/packages.config
+++ b/src/Void.Lang.Interpreter.Spec/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FsUnit" version="1.3.0.1" targetFramework="net45" />
+  <package id="FsUnit" version="1.4.0.0-beta" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/Void.Lang.Interpreter/Void.Lang.Interpreter.fsproj
+++ b/src/Void.Lang.Interpreter/Void.Lang.Interpreter.fsproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\Void.Lang.Interpreter.XML</DocumentationFile>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\Void.Lang.Interpreter.XML</DocumentationFile>

--- a/src/Void.Lang.Parser.Spec/Void.Lang.Parser.Spec.fsproj
+++ b/src/Void.Lang.Parser.Spec/Void.Lang.Parser.Spec.fsproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\Void.Lang.Parser.Spec.XML</DocumentationFile>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\Void.Lang.Parser.Spec.XML</DocumentationFile>

--- a/src/Void.Lang.Parser.Spec/Void.Lang.Parser.Spec.fsproj
+++ b/src/Void.Lang.Parser.Spec/Void.Lang.Parser.Spec.fsproj
@@ -68,11 +68,15 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FsUnit.NUnit">
-      <HintPath>..\packages\FsUnit.1.3.0.1\Lib\Net40\FsUnit.NUnit.dll</HintPath>
+      <HintPath>..\packages\FsUnit.1.4.0.0-beta\lib\FsUnit.NUnit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NHamcrest">
+      <HintPath>..\packages\FsUnit.1.4.0.0-beta\lib\NHamcrest.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">

--- a/src/Void.Lang.Parser.Spec/packages.config
+++ b/src/Void.Lang.Parser.Spec/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FsUnit" version="1.3.0.1" targetFramework="net45" />
+  <package id="FsUnit" version="1.4.0.0-beta" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/Void.Lang.Parser/Void.Lang.Parser.fsproj
+++ b/src/Void.Lang.Parser/Void.Lang.Parser.fsproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\Void.Lang.Parser.XML</DocumentationFile>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\Void.Lang.Parser.XML</DocumentationFile>

--- a/src/Void.Spec/Void.Spec.fsproj
+++ b/src/Void.Spec/Void.Spec.fsproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\Void.Spec.XML</DocumentationFile>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\Void.Spec.XML</DocumentationFile>

--- a/src/Void.Spec/Void.Spec.fsproj
+++ b/src/Void.Spec/Void.Spec.fsproj
@@ -68,11 +68,15 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FsUnit.NUnit">
-      <HintPath>..\packages\FsUnit.1.3.0.1\Lib\Net40\FsUnit.NUnit.dll</HintPath>
+      <HintPath>..\packages\FsUnit.1.4.0.0-beta\lib\FsUnit.NUnit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NHamcrest">
+      <HintPath>..\packages\FsUnit.1.4.0.0-beta\lib\NHamcrest.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">

--- a/src/Void.Spec/packages.config
+++ b/src/Void.Spec/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FsUnit" version="1.3.0.1" targetFramework="net45" />
+  <package id="FsUnit" version="1.4.0.0-beta" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/Void.UI/MainForm.cs
+++ b/src/Void.UI/MainForm.cs
@@ -46,6 +46,19 @@ namespace Void.UI
                     TriggerDraw(((VMEvent.ViewPortionRendered)eventMsg).Item1);
                 }
             }
+            if (eventMsg.IsMultipleViewPortionsRendered)
+            {
+                var blocks = new List<PointGrid.Block>();
+                foreach (var viewPortionRenderd in ((VMEvent.MultipleViewPortionsRendered) eventMsg).Item)
+                {
+                    _drawings.AddRange(viewPortionRenderd.Item2);
+                    blocks.Add(viewPortionRenderd.Item1);
+                }
+                if (_cellMetrics != null)
+                {
+                    TriggerDraw(blocks);
+                }
+            }
             if (eventMsg.IsViewModelInitialized)
             {
                 var viewModel = ((VMEvent.ViewModelInitialized)eventMsg).Item;
@@ -140,9 +153,21 @@ namespace Void.UI
             Text = title;
         }
 
-        public void TriggerDraw(PointGrid.Block block)
+        private void TriggerDraw(PointGrid.Block block)
         {
             Invalidate(block.AsWinFormsRectangle(_cellMetrics));
+        }
+
+        private void TriggerDraw(IEnumerable<PointGrid.Block> blocks)
+        {
+            var regions = blocks.Select(block => block.AsWinFormsRectangle(_cellMetrics))
+                .Select(rect => new Region(rect));
+            var cumulativeRegion = new Region();
+            foreach (var region in regions)
+            {
+                cumulativeRegion.Union(region);
+            }
+            Invalidate(cumulativeRegion);
         }
     }
 }

--- a/src/Void.UI/TypeTranslationExtensions.cs
+++ b/src/Void.UI/TypeTranslationExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
 using Microsoft.FSharp.Core;
 using Void.Core;
@@ -79,6 +81,11 @@ namespace Void.UI
         public static Func<TextOrHotKey,Unit> AsTextAndHotKeysHandler(this InputMode<Unit> inputMode)
         {
             return ((InputMode<Unit>.TextAndHotKeys) inputMode).Item.Invoke;
+        }
+
+        public static IEnumerable<VMEvent.ViewPortionRendered> Split(this VMEvent.MultipleViewPortionsRendered multiple)
+        {
+            return multiple.Item.Select(x => (VMEvent.ViewPortionRendered)VMEvent.NewViewPortionRendered(x.Item1, x.Item2));
         }
 
         public static KeyPress AsVoidKeyPress(this KeyEventArgs keyEvent)

--- a/src/Void.UI/Void.UI.csproj
+++ b/src/Void.UI/Void.UI.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\build\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -27,7 +27,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\..\build\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/Void.ViewModel.Spec/CommandBarSpec.fs
+++ b/src/Void.ViewModel.Spec/CommandBarSpec.fs
@@ -32,7 +32,7 @@ type ``The command mode command line (or command bar for short)``() =
     member x.``should remove the last character when it is backspaced``() =
         let bar, msg = CommandBar.handleCommandModeEvent visibleQui5 CommandMode.Event.CharacterBackspaced
         bar |> should equal visibleQui
-        msg |> should equal (CommandBar.Event.CharacterBackspacedFromLine { Row = 0; Column = 4 })
+        msg |> should equal (CommandBar.Event.CharacterBackspacedFromLine { Row = 0<mRow>; Column = 4<mColumn> })
 
     [<Test>]
     member x.``should reflow the text when backspace results in removal of line``() =
@@ -44,7 +44,7 @@ type ``The command mode command line (or command bar for short)``() =
     member x.``should add characters when text is appended``() =
         let bar, msg = CommandBar.handleCommandModeEvent visibleQui <| CommandMode.Event.TextAppended "5"
         bar |> should equal visibleQui5
-        msg |> should equal (CommandBar.Event.TextAppendedToLine { LeftMostCell = { Row = 0; Column = 4 }; Text = "5" })
+        msg |> should equal (CommandBar.Event.TextAppendedToLine { LeftMostCell = { Row = 0<mRow>; Column = 4<mColumn> }; Text = "5" })
 
     [<Test>]
     member x.``should reflow the text when an added character results in a second line``() =

--- a/src/Void.ViewModel.Spec/RenderCommandBarSpec.fs
+++ b/src/Void.ViewModel.Spec/RenderCommandBarSpec.fs
@@ -11,7 +11,7 @@ open FsUnit
 type ``Rendering the command bar``() = 
     [<Test>]
     member x.``when it is hidden results in a background block``() =
-        let (_, drawings) = RenderCommandBar.asDrawingObjects CommandBar.hidden { Row = 24; Column = 0 }
+        let (_, drawings) = RenderCommandBar.asDrawingObjects CommandBar.hidden { Row = 24<mRow>; Column = 0<mColumn> }
         let drawings = List.ofSeq drawings
         drawings.Length |> should equal 1
         drawings.[0] |> should equal (DrawingObject.Block {
@@ -25,7 +25,7 @@ type ``Rendering the command bar``() =
 
     [<Test>]
     member x.``when it is shown but empty results in a prompt symbol``() =
-        let (_, drawings) = RenderCommandBar.asDrawingObjects CommandBar.visibleButEmpty { Row = 25; Column = 0 }
+        let (_, drawings) = RenderCommandBar.asDrawingObjects CommandBar.visibleButEmpty { Row = 25<mRow>; Column = 0<mColumn> }
         let drawings = List.ofSeq drawings
         drawings.Length |> should equal 2
         drawings.[1] |> should equal (DrawingObject.Text {
@@ -36,7 +36,7 @@ type ``Rendering the command bar``() =
 
     [<Test>]
     member x.``when it is shown but empty results in a prompt symbol (classic Vim mode)``() =
-        let (_, drawings) = RenderCommandBar.asDrawingObjects { Prompt = Visible CommandBarPrompt.ClassicVim; WrappedLines = [""]; Width = 80 } { Row = 25; Column = 0 }
+        let (_, drawings) = RenderCommandBar.asDrawingObjects { Prompt = Visible CommandBarPrompt.ClassicVim; WrappedLines = [""]; Width = 80 } { Row = 25<mRow>; Column = 0<mColumn> }
         let drawings = List.ofSeq drawings
         drawings.Length |> should equal 2
         drawings.[1] |> should equal (DrawingObject.Text {
@@ -47,7 +47,7 @@ type ``Rendering the command bar``() =
 
     [<Test>]
     member x.``when it is shown and has text results in a prompt symbol and text``() =
-        let (_, drawings) = RenderCommandBar.asDrawingObjects { Prompt = Visible CommandBarPrompt.VoidDefault; WrappedLines = ["quit"]; Width = 80 } { Row = 25; Column = 0 }
+        let (_, drawings) = RenderCommandBar.asDrawingObjects { Prompt = Visible CommandBarPrompt.VoidDefault; WrappedLines = ["quit"]; Width = 80 } { Row = 25<mRow>; Column = 0<mColumn> }
         let drawings = List.ofSeq drawings
         drawings.Length |> should equal 3
         drawings.[2] |> should equal (DrawingObject.Text {

--- a/src/Void.ViewModel.Spec/RenderNotificationBarSpec.fs
+++ b/src/Void.ViewModel.Spec/RenderNotificationBarSpec.fs
@@ -12,12 +12,12 @@ type ``Rendering user notifications``() =
     let render = RenderNotificationBar.asDrawingObjects
     [<Test>]
     member x.``when there are none results in no drawing objects``() =
-        render 78 { Row = 24; Column = 0 } [] 
+        render 78 { Row = 24<mRow>; Column = 0<mColumn> } [] 
         |> should equal []
 
     [<Test>]
     member x.``when there is one error renders it in error colors``() =
-        render 78 { Row = 24; Column = 0 } [UserNotificationView.Error "Bad!"]
+        render 78 { Row = 24<mRow>; Column = 0<mColumn> } [UserNotificationView.Error "Bad!"]
         |> should equal [DrawingObject.Text {
             Text = "Bad!"
             UpperLeftCorner = { Y = 24; X = 0 }
@@ -26,7 +26,7 @@ type ``Rendering user notifications``() =
 
     [<Test>]
     member x.``when there is one notification renders it in regular colors``() =
-        render 80 { Row = 25; Column = 0 } [UserNotificationView.Text "Good"]
+        render 80 { Row = 25<mRow>; Column = 0<mColumn> } [UserNotificationView.Text "Good"]
         |> should equal [DrawingObject.Text {
             Text = "Good"
             UpperLeftCorner = { Y = 25; X = 0 }

--- a/src/Void.ViewModel.Spec/RenderWindowsSpec.fs
+++ b/src/Void.ViewModel.Spec/RenderWindowsSpec.fs
@@ -20,7 +20,7 @@ type ``Rendering text lines as drawing objects for a view size``() =
 
 [<TestFixture>]
 type ``Rendering buffers``() = 
-    let render = RenderWindows.contentsAsDrawingObjects { Rows = 25; Columns = 80 }
+    let render = RenderWindows.contentsAsDrawingObjects { Rows = 25<mRow>; Columns = 80<mColumn> }
 
     let shouldAllBeTildes drawingObjects =
         drawingObjects |> Seq.mapi (fun i drawingObject ->

--- a/src/Void.ViewModel.Spec/RenderWindowsSpec.fs
+++ b/src/Void.ViewModel.Spec/RenderWindowsSpec.fs
@@ -81,6 +81,23 @@ type ``Rendering buffers``() =
         })
 
     [<Test>]
+    member x.``when the buffer has text and is focused and the cursor is not at the origin, it renders the normal-mode cursor``() =
+        let cursorCell = { Row = 1<mRow>; Column = 1<mColumn> }
+        let cursor = Visible <| CursorView.Block cursorCell
+        let window = { Window.defaultWindowView with Buffer = ["foo"; "bar"; "bez"]; Cursor = cursor }
+        let drawingObjects = RenderWindows.windowAsDrawingObjects window
+        drawingObjects.Length |> should equal 28
+        drawingObjects.[26] |> should equal (DrawingObject.Block {
+            Area = GridConvert.boxAroundOneCell cursorCell
+            Color = Colors.defaultColorscheme.Foreground
+        })
+        drawingObjects.[27] |> should equal (DrawingObject.Text {
+            Text = "a"
+            UpperLeftCorner = GridConvert.upperLeftCornerOf cursorCell
+            Color = Colors.defaultColorscheme.Background
+        })
+
+    [<Test>]
     member x.``when the buffer has multple lines, but less than the rows that are available in the window``() =
         let drawingObjects = render ["line 1"; "line 2"]
         drawingObjects.Length |> should equal 26

--- a/src/Void.ViewModel.Spec/RenderWindowsSpec.fs
+++ b/src/Void.ViewModel.Spec/RenderWindowsSpec.fs
@@ -148,20 +148,20 @@ type ``Rendering buffers``() =
                 let drawingObject2 = Seq.last viewPortion1
                 let drawingObject3 = Seq.head viewPortion2
                 let drawingObject4 = Seq.last viewPortion2
-                drawingObject1 |> shouldEqual (DrawingObject.Block {
+                drawingObject1 |> should equal (DrawingObject.Block {
                     Area = block1
                     Color = Colors.defaultColorscheme.Background
                 })
-                drawingObject2 |> shouldEqual (DrawingObject.Text {
+                drawingObject2 |> should equal (DrawingObject.Text {
                     Text = "f"
                     UpperLeftCorner = PointGrid.originPoint
                     Color = Colors.defaultColorscheme.Foreground
                 })
-                drawingObject3 |> shouldEqual (DrawingObject.Block {
+                drawingObject3 |> should equal (DrawingObject.Block {
                     Area = block2
                     Color = Colors.defaultColorscheme.Foreground
                 })
-                drawingObject4 |> shouldEqual (DrawingObject.Text {
+                drawingObject4 |> should equal (DrawingObject.Text {
                     Text = "a"
                     UpperLeftCorner = GridConvert.upperLeftCornerOf cursorCell
                     Color = Colors.defaultColorscheme.Background

--- a/src/Void.ViewModel.Spec/RenderWindowsSpec.fs
+++ b/src/Void.ViewModel.Spec/RenderWindowsSpec.fs
@@ -37,7 +37,7 @@ type ``Rendering buffers``() =
         })
 
     [<Test>]
-    member x.``when the buffer is empty it renders as a background-colored area with muted tildes on each line except the first``() =
+    member x.``when the buffer is empty and unfocused it renders as a background-colored area with muted tildes on each line except the first``() =
         // TODO when you open an empty buffer in Vim, why is there no tilde in the first line?
         let drawingObjects =  render []
         drawingObjects.Length |> should equal 25
@@ -45,7 +45,16 @@ type ``Rendering buffers``() =
         drawingObjects.Tail |> shouldAllBeTildes
 
     [<Test>]
-    member x.``when the buffer has one line it renders that line and but otherwise is like an empty buffer``() =
+    member x.``when the buffer is empty and focused it renders the normal-mode cursor at the origin cell``() =
+        let drawingObjects = RenderWindows.windowAsDrawingObjects Window.defaultWindowView
+        drawingObjects.Length |> should equal 26
+        drawingObjects.[25] |> should equal (DrawingObject.Block {
+            Area = GridConvert.boxAroundOneCell originCell
+            Color = Colors.defaultColorscheme.Foreground
+        })
+
+    [<Test>]
+    member x.``when the buffer has one line it renders that line but otherwise is like an empty buffer``() =
         let drawingObjects = render ["only one line"]
         drawingObjects.Length |> should equal 26
         drawingObjects.[0] |> shouldBeBackgroundBlock
@@ -55,6 +64,21 @@ type ``Rendering buffers``() =
             Color = Colors.defaultColorscheme.Foreground
         })
         drawingObjects |> Seq.skip 2 |> shouldAllBeTildes
+
+    [<Test>]
+    member x.``when the buffer has one line and is focused it renders the normal-mode cursor``() =
+        let window = { Window.defaultWindowView with Buffer = ["foo"] }
+        let drawingObjects = RenderWindows.windowAsDrawingObjects window
+        drawingObjects.Length |> should equal 28
+        drawingObjects.[26] |> should equal (DrawingObject.Block {
+            Area = GridConvert.boxAroundOneCell originCell
+            Color = Colors.defaultColorscheme.Foreground
+        })
+        drawingObjects.[27] |> should equal (DrawingObject.Text {
+            Text = "f"
+            UpperLeftCorner = PointGrid.originPoint
+            Color = Colors.defaultColorscheme.Background
+        })
 
     [<Test>]
     member x.``when the buffer has multple lines, but less than the rows that are available in the window``() =

--- a/src/Void.ViewModel.Spec/Void.ViewModel.Spec.fsproj
+++ b/src/Void.ViewModel.Spec/Void.ViewModel.Spec.fsproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\Void.ViewModel.Spec.XML</DocumentationFile>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\Void.ViewModel.Spec.XML</DocumentationFile>

--- a/src/Void.ViewModel.Spec/Void.ViewModel.Spec.fsproj
+++ b/src/Void.ViewModel.Spec/Void.ViewModel.Spec.fsproj
@@ -65,11 +65,15 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FsUnit.NUnit">
-      <HintPath>..\packages\FsUnit.1.3.0.1\Lib\Net40\FsUnit.NUnit.dll</HintPath>
+      <HintPath>..\packages\FsUnit.1.4.0.0-beta\lib\FsUnit.NUnit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NHamcrest">
+      <HintPath>..\packages\FsUnit.1.4.0.0-beta\lib\NHamcrest.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">

--- a/src/Void.ViewModel.Spec/WindowSpec.fs
+++ b/src/Void.ViewModel.Spec/WindowSpec.fs
@@ -251,7 +251,16 @@ type ``Moving the cursor``() =
 
     [<Test>]
     member x.``When the buffer cursor moves below what is visible in the window, the buffer is scrolled down``() =
-        ()
+        let startCell = below originCell 24<mRow>
+        let buffer =
+            Seq.initInfinite (sprintf "%i")
+            |> Seq.take 25
+            |> Seq.toList
+        let window = { Window.defaultWindowView with Buffer = buffer }
+
+        { BufferId = 1; Message = BufferEvent.CursorMoved(startCell, below startCell 5<mRow>) }
+        |> Window.handleBufferEvent window
+        |> should equal (window, VMCommand.Scroll (Move.forward By.line 5) :> Message)
 
     [<Test>]
     member x.``When the buffer cursor moves above what is visible in the window, the buffer is scrolled up``() =

--- a/src/Void.ViewModel.Spec/WindowSpec.fs
+++ b/src/Void.ViewModel.Spec/WindowSpec.fs
@@ -255,4 +255,8 @@ type ``Moving the cursor``() =
 
     [<Test>]
     member x.``When the buffer cursor moves above what is visible in the window, the buffer is scrolled up``() =
-        ()
+        let window = { Window.defaultWindowView with Buffer = ["z"]; TopLineNumber = 30<mLine> }
+
+        { BufferId = 1; Message = BufferEvent.CursorMoved(below originCell 29<mRow>, below originCell 26<mRow>) }
+        |> Window.handleBufferEvent window
+        |> should equal (window, VMCommand.Scroll (Move.backward By.line 3) :> Message)

--- a/src/Void.ViewModel.Spec/WindowSpec.fs
+++ b/src/Void.ViewModel.Spec/WindowSpec.fs
@@ -74,7 +74,7 @@ type ``Scrolling (by line)``() =
     member x.``up when we are already at the top of the file should do nothing``() =
         let windowBefore = { Window.defaultWindowView with Buffer = !buffer }
 
-        Move.Backward 3<mLine>
+        Move.backward By.line 3
         |> scroll windowBefore 
         |> shouldEqual (windowBefore, noMessage)
 
@@ -83,7 +83,7 @@ type ``Scrolling (by line)``() =
         let windowBefore = { Window.defaultWindowView with Buffer = ["b"; "c"; "d"; "e"; "f"]; TopLineNumber = 2<mLine> }
         let windowAfter = { windowBefore with TopLineNumber = 1<mLine>; Buffer = !buffer }
 
-        Move.Backward 1<mLine>
+        Move.backward By.line 1
         |> scroll windowBefore 
         |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
 
@@ -92,7 +92,7 @@ type ``Scrolling (by line)``() =
         let windowBefore = { Window.defaultWindowView with Buffer = ["d"; "e"; "f"]; TopLineNumber = 4<mLine> }
         let windowAfter = { windowBefore with TopLineNumber = 1<mLine>; Buffer = !buffer }
 
-        Move.Backward 3<mLine>
+        Move.backward By.line 3
         |> scroll windowBefore 
         |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
 
@@ -101,7 +101,7 @@ type ``Scrolling (by line)``() =
         let windowBefore = { Window.defaultWindowView with Buffer = ["d"; "e"; "f"]; TopLineNumber = 3<mLine> }
         let windowAfter = { windowBefore with TopLineNumber = 1<mLine>; Buffer = !buffer }
 
-        Move.Backward 4<mLine>
+        Move.backward By.line 4
         |> scroll windowBefore 
         |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
 
@@ -110,7 +110,7 @@ type ``Scrolling (by line)``() =
         buffer := []
         let windowBefore = Window.defaultWindowView
 
-        Move.Backward 1<mLine>
+        Move.backward By.line 1
         |> scroll windowBefore 
         |> shouldEqual (windowBefore, noMessage)
 
@@ -119,7 +119,7 @@ type ``Scrolling (by line)``() =
         buffer := []
         let windowBefore = Window.defaultWindowView
 
-        Move.Forward 1<mLine>
+        Move.forward By.line 1
         |> scroll windowBefore 
         |> shouldEqual (windowBefore, noMessage)
 
@@ -127,7 +127,7 @@ type ``Scrolling (by line)``() =
     member x.``down when only the last line of the buffer is showing should do nothing``() =
         let windowBefore = { Window.defaultWindowView with TopLineNumber = 6<mLine>; Buffer = ["f"] }
 
-        Move.Forward 1<mLine>
+        Move.forward By.line 1
         |> scroll windowBefore 
         |> shouldEqual (windowBefore, noMessage)
 
@@ -136,7 +136,7 @@ type ``Scrolling (by line)``() =
         let windowBefore = { Window.defaultWindowView with Buffer = !buffer }
         let windowAfter = { windowBefore with TopLineNumber = 4<mLine>; Buffer = ["d"; "e"; "f"] }
 
-        Move.Forward 3<mLine>
+        Move.forward By.line 3
         |> scroll windowBefore 
         |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
 
@@ -165,7 +165,7 @@ type ``Scrolling (by half screen)``() =
     member x.``up when we are already at the top of the file should do nothing``() =
         let windowBefore = { Window.defaultWindowView with Buffer = !buffer }
 
-        Move.Backward 1<mScreenHeight>
+        Move.backward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
         |> shouldEqual (windowBefore, noMessage)
 
@@ -174,7 +174,7 @@ type ``Scrolling (by half screen)``() =
         let windowBefore = { Window.defaultWindowView with Buffer = ["b"; "c"; "d"; "e"; "f"]; TopLineNumber = 2<mLine> }
         let windowAfter = { windowBefore with TopLineNumber = 1<mLine>; Buffer = !buffer }
 
-        Move.Backward 1<mScreenHeight>
+        Move.backward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
         |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
 
@@ -183,7 +183,7 @@ type ``Scrolling (by half screen)``() =
         buffer := []
         let windowBefore = Window.defaultWindowView
 
-        Move.Backward 1<mScreenHeight>
+        Move.backward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
         |> shouldEqual (windowBefore, noMessage)
 
@@ -192,7 +192,7 @@ type ``Scrolling (by half screen)``() =
         buffer := []
         let windowBefore = Window.defaultWindowView
 
-        Move.Forward 1<mScreenHeight>
+        Move.forward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
         |> shouldEqual (windowBefore, noMessage)
 
@@ -200,7 +200,7 @@ type ``Scrolling (by half screen)``() =
     member x.``down when only the last line of the buffer is showing should do nothing``() =
         let windowBefore = { Window.defaultWindowView with TopLineNumber = 6<mLine>; Buffer = ["f"] }
 
-        Move.Forward 1<mScreenHeight>
+        Move.forward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
         |> shouldEqual (windowBefore, noMessage)
 
@@ -209,7 +209,7 @@ type ``Scrolling (by half screen)``() =
         let windowBefore = { Window.defaultWindowView with Buffer = !buffer }
         let windowAfter = { windowBefore with TopLineNumber = 6<mLine>; Buffer = ["f"] }
 
-        Move.Forward 1<mScreenHeight>
+        Move.forward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
         |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
 
@@ -219,6 +219,6 @@ type ``Scrolling (by half screen)``() =
         let windowBefore = { Window.defaultWindowView with Buffer = !buffer; Dimensions = dimensions }
         let windowAfter = { windowBefore with TopLineNumber = 6<mLine>; Buffer = ["f"] }
 
-        Move.Forward 1<mScreenHeight>
+        Move.forward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
         |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)

--- a/src/Void.ViewModel.Spec/WindowSpec.fs
+++ b/src/Void.ViewModel.Spec/WindowSpec.fs
@@ -8,13 +8,6 @@ open System.Linq
 open NUnit.Framework
 open FsUnit
 
-[<AutoOpen>]
-module Assertions =
-    let shouldEqual expected actual =
-        printfn "Expected: %A" expected
-        printfn "Actual: %A" actual
-        should equal expected actual
-
 [<TestFixture>]
 type ``Constructing a buffer view model from a sequence of text lines``() = 
     let asViewModelBuffer = Window.bufferFrom { Rows = 25<mRow>; Columns = 80<mColumn> }
@@ -76,7 +69,7 @@ type ``Scrolling (by line)``() =
 
         Move.backward By.line 3
         |> scroll windowBefore 
-        |> shouldEqual (windowBefore, noMessage)
+        |> should equal (windowBefore, noMessage)
 
     [<Test>]
     member x.``up one line when the top line is two should work``() =
@@ -85,7 +78,7 @@ type ``Scrolling (by line)``() =
 
         Move.backward By.line 1
         |> scroll windowBefore 
-        |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
+        |> should equal (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
 
     [<Test>]
     member x.``up three lines when the top line is four should go to the top of the file``() =
@@ -94,7 +87,7 @@ type ``Scrolling (by line)``() =
 
         Move.backward By.line 3
         |> scroll windowBefore 
-        |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
+        |> should equal (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
 
     [<Test>]
     member x.``up four lines when the top line is three should go to the top of the file``() =
@@ -103,7 +96,7 @@ type ``Scrolling (by line)``() =
 
         Move.backward By.line 4
         |> scroll windowBefore 
-        |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
+        |> should equal (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
 
     [<Test>]
     member x.``up when the buffer is empty should do nothing``() =
@@ -112,7 +105,7 @@ type ``Scrolling (by line)``() =
 
         Move.backward By.line 1
         |> scroll windowBefore 
-        |> shouldEqual (windowBefore, noMessage)
+        |> should equal (windowBefore, noMessage)
 
     [<Test>]
     member x.``down when the buffer is empty should do nothing``() =
@@ -121,7 +114,7 @@ type ``Scrolling (by line)``() =
 
         Move.forward By.line 1
         |> scroll windowBefore 
-        |> shouldEqual (windowBefore, noMessage)
+        |> should equal (windowBefore, noMessage)
 
     [<Test>]
     member x.``down when only the last line of the buffer is showing should do nothing``() =
@@ -129,7 +122,7 @@ type ``Scrolling (by line)``() =
 
         Move.forward By.line 1
         |> scroll windowBefore 
-        |> shouldEqual (windowBefore, noMessage)
+        |> should equal (windowBefore, noMessage)
 
     [<Test>]
     member x.``down multiple lines from the top``() =
@@ -138,7 +131,7 @@ type ``Scrolling (by line)``() =
 
         Move.forward By.line 3
         |> scroll windowBefore 
-        |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
+        |> should equal (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
 
 [<TestFixture>]
 type ``Scrolling (by half screen)``() = 
@@ -167,7 +160,7 @@ type ``Scrolling (by half screen)``() =
 
         Move.backward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
-        |> shouldEqual (windowBefore, noMessage)
+        |> should equal (windowBefore, noMessage)
 
     [<Test>]
     member x.``up half a screen height when the top line is two should go to the top of the file``() =
@@ -176,7 +169,7 @@ type ``Scrolling (by half screen)``() =
 
         Move.backward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
-        |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
+        |> should equal (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
 
     [<Test>]
     member x.``up when the buffer is empty should do nothing``() =
@@ -185,7 +178,7 @@ type ``Scrolling (by half screen)``() =
 
         Move.backward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
-        |> shouldEqual (windowBefore, noMessage)
+        |> should equal (windowBefore, noMessage)
 
     [<Test>]
     member x.``down when the buffer is empty should do nothing``() =
@@ -194,7 +187,7 @@ type ``Scrolling (by half screen)``() =
 
         Move.forward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
-        |> shouldEqual (windowBefore, noMessage)
+        |> should equal (windowBefore, noMessage)
 
     [<Test>]
     member x.``down when only the last line of the buffer is showing should do nothing``() =
@@ -202,7 +195,7 @@ type ``Scrolling (by half screen)``() =
 
         Move.forward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
-        |> shouldEqual (windowBefore, noMessage)
+        |> should equal (windowBefore, noMessage)
 
     [<Test>]
     member x.``down when less than half a screen is showing should leave last line showing``() =
@@ -211,7 +204,7 @@ type ``Scrolling (by half screen)``() =
 
         Move.forward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
-        |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
+        |> should equal (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
 
     [<Test>]
     member x.``down when exactly half a screen is showing should leave the last line showing``() =
@@ -221,7 +214,7 @@ type ``Scrolling (by half screen)``() =
 
         Move.forward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
-        |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
+        |> should equal (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
 
 [<TestFixture>]
 type ``Moving the cursor``() = 

--- a/src/Void.ViewModel.Spec/WindowSpec.fs
+++ b/src/Void.ViewModel.Spec/WindowSpec.fs
@@ -17,7 +17,7 @@ module Assertions =
 
 [<TestFixture>]
 type ``Constructing a buffer view model from a sequence of text lines``() = 
-    let asViewModelBuffer = Window.bufferFrom { Rows = 25; Columns = 80 }
+    let asViewModelBuffer = Window.bufferFrom { Rows = 25<mRow>; Columns = 80<mColumn> }
 
     [<Test>]
     member x.``should create an empty buffer view model from an empty buffer``() =
@@ -215,7 +215,7 @@ type ``Scrolling (by half screen)``() =
 
     [<Test>]
     member x.``down when exactly half a screen is showing should leave the last line showing``() =
-        let dimensions = { Rows = 12; Columns = 60 }
+        let dimensions = { Rows = 12<mRow>; Columns = 60<mColumn> }
         let windowBefore = { Window.defaultWindowView with Buffer = !buffer; Dimensions = dimensions }
         let windowAfter = { windowBefore with TopLineNumber = 6<mLine>; Buffer = ["f"] }
 

--- a/src/Void.ViewModel.Spec/WindowSpec.fs
+++ b/src/Void.ViewModel.Spec/WindowSpec.fs
@@ -222,3 +222,37 @@ type ``Scrolling (by half screen)``() =
         Move.forward vmBy.screenHeight 1
         |> scrollHalf windowBefore 
         |> shouldEqual (windowAfter, Window.Event.ContentsUpdated windowAfter :> Message)
+
+[<TestFixture>]
+type ``Moving the cursor``() = 
+    [<Test>]
+    member x.``When the cursor is moved in the buffer, it is moved in the window``() =
+        let targetCell = below originCell 1<mRow>
+        let windowBefore = { Window.defaultWindowView with Buffer = ["a"; "b"]}
+        let windowAfter = { windowBefore with Cursor = Visibility.Visible <| CursorView.Block targetCell }
+
+        { BufferId = 1; Message = BufferEvent.CursorMoved(originCell, targetCell) }
+        |> Window.handleBufferEvent windowBefore
+        |> should equal (windowAfter, Window.Event.CursorMoved(originCell, targetCell, windowAfter) :> Message)
+
+    [<Test>]
+    member x.``The cursor in the window is tracked relative to the window, not the buffer``() =
+        let targetCell = below originCell 1<mRow>
+        let buffer =
+            Seq.initInfinite (sprintf "%i")
+            |> Seq.take 25
+            |> Seq.toList
+        let windowBefore = { Window.defaultWindowView with Buffer = buffer; TopLineNumber = 10<mLine> }
+        let windowAfter = { windowBefore with Cursor = Visibility.Visible <| CursorView.Block targetCell }
+
+        { BufferId = 1; Message = BufferEvent.CursorMoved(below originCell 9<mRow>, below targetCell 9<mRow>) }
+        |> Window.handleBufferEvent windowBefore
+        |> should equal (windowAfter, Window.Event.CursorMoved(originCell, targetCell, windowAfter) :> Message)
+
+    [<Test>]
+    member x.``When the buffer cursor moves below what is visible in the window, the buffer is scrolled down``() =
+        ()
+
+    [<Test>]
+    member x.``When the buffer cursor moves above what is visible in the window, the buffer is scrolled up``() =
+        ()

--- a/src/Void.ViewModel.Spec/packages.config
+++ b/src/Void.ViewModel.Spec/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FsUnit" version="1.3.0.1" targetFramework="net45" />
+  <package id="FsUnit" version="1.4.0.0-beta" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/Void.ViewModel/CommandBar.fs
+++ b/src/Void.ViewModel/CommandBar.fs
@@ -48,7 +48,7 @@ module CommandBar =
         interface EventMessage
 
     let private lastCell commandBar = 
-        CellGrid.rightOf CellGrid.originCell commandBar.WrappedLines.Head.Length
+        CellGrid.rightOf CellGrid.originCell (commandBar.WrappedLines.Head.Length * 1<mColumn>)
 
     let private currentLineWillOverflow (textToAppend : string) commandBar =
         if commandBar.WrappedLines = [] // TODO this is a hack to avoid an exception
@@ -75,7 +75,7 @@ module CommandBar =
             // TODO: I ran into an exception here
             let line = commandBar.WrappedLines.Head + textToAppend
             let bar = { commandBar with WrappedLines = line :: commandBar.WrappedLines.Tail }
-            let textSegment = { LeftMostCell = CellGrid.rightOf (lastCell commandBar) 1; Text = textToAppend }
+            let textSegment = { LeftMostCell = CellGrid.rightOf (lastCell commandBar) 1<mColumn>; Text = textToAppend }
             (bar, Event.TextAppendedToLine textSegment :> Message)
 
     let private characterBackspaced commandBar =

--- a/src/Void.ViewModel/RenderCommandBar.fs
+++ b/src/Void.ViewModel/RenderCommandBar.fs
@@ -15,8 +15,8 @@ module RenderCommandBar =
     let private renderLines origin lines =
         let startingCellForLineNumber i =
            if i = 0
-           then CellGrid.rightOf origin 1
-           else CellGrid.below origin i
+           then CellGrid.rightOf origin 1<mColumn>
+           else CellGrid.below origin (i * 1<mRow>)
            |> GridConvert.upperLeftCornerOf
 
         let renderLine i text =

--- a/src/Void.ViewModel/RenderNotificationBar.fs
+++ b/src/Void.ViewModel/RenderNotificationBar.fs
@@ -35,7 +35,7 @@ module RenderNotificationBar =
         | CoreEvent.NotificationAdded notification ->
             let area = {
                 UpperLeftCell = !notificationsOrigin
-                Dimensions = { Rows = 1; Columns = 80 }
+                Dimensions = { Rows = 1<mRow>; Columns = 80<mColumn> }
             }
             let drawing = toScreenNotification notification
                           |> notificationAsDrawingObject !notificationsOrigin

--- a/src/Void.ViewModel/RenderWindows.fs
+++ b/src/Void.ViewModel/RenderWindows.fs
@@ -39,7 +39,9 @@ module RenderWindows =
         List.append (background :: bufferLines) rowsNotInBuffer
 
     let private getCharacter (buffer : string list) cell =
-        buffer.[cell.Row/1<mRow>].[cell.Column/1<mColumn>].ToString()
+        match buffer.[cell.Row/1<mRow>] with
+          | "" -> ""
+          | text -> text.[cell.Column/1<mColumn>].ToString()
 
     let private cursorAsDrawingObjects (window : WindowView) =
         match window.Cursor with

--- a/src/Void.ViewModel/RenderWindows.fs
+++ b/src/Void.ViewModel/RenderWindows.fs
@@ -7,7 +7,7 @@ module RenderWindows =
     let private textLineAsDrawingObject x line =
         DrawingObject.Text {
             Text = line
-            UpperLeftCorner = GridConvert.upperLeftCornerOf <| below originCell x
+            UpperLeftCorner = GridConvert.upperLeftCornerOf <| below originCell (x * 1<mRow>)
             Color = Colors.defaultColorscheme.Foreground
         }
 
@@ -26,14 +26,14 @@ module RenderWindows =
             let lineNotInBufferAsDrawingObject i =
                 DrawingObject.Text {
                     Text = "~"
-                    UpperLeftCorner = GridConvert.upperLeftCornerOf { Row = i; Column = 0 }
+                    UpperLeftCorner = GridConvert.upperLeftCornerOf { Row = i * 1<mRow>; Column = 0<mColumn> }
                     Color = Colors.defaultColorscheme.DimForeground
                 }
             let linesWithNoTilde =
                 if bufferLines.Length = 0
                 then 1
                 else bufferLines.Length
-            [linesWithNoTilde..dimensions.Rows-1]
+            [linesWithNoTilde..(dimensions.Rows / 1<mRow> - 1)]
             |> List.map lineNotInBufferAsDrawingObject
 
         List.append (background :: bufferLines) rowsNotInBuffer

--- a/src/Void.ViewModel/RenderWindows.fs
+++ b/src/Void.ViewModel/RenderWindows.fs
@@ -41,7 +41,7 @@ module RenderWindows =
     let private getCharacter (buffer : string list) cell =
         buffer.[cell.Row/1<mRow>].[cell.Column/1<mColumn>].ToString()
 
-    let cursorAsDrawingObjects (window : WindowView) =
+    let private cursorAsDrawingObjects (window : WindowView) =
         match window.Cursor with
         | Visible cursor ->
             match cursor with
@@ -77,6 +77,8 @@ module RenderWindows =
             renderWindow window
         | Window.Event.Initialized window ->
             renderWindow window
+        | Window.Event.CursorMoved (fromCell, window) ->
+            renderWindow window // TODO optimize: render only fromCell and toCell
 
     let handleWindowCommand (Window.Command.RedrawWindow window) =
         renderWindow window

--- a/src/Void.ViewModel/RenderWindows.fs
+++ b/src/Void.ViewModel/RenderWindows.fs
@@ -38,6 +38,9 @@ module RenderWindows =
 
         List.append (background :: bufferLines) rowsNotInBuffer
 
+    let private getCharacter (buffer : string list) cell =
+        buffer.[cell.Row/1<mRow>].[cell.Column/1<mColumn>].ToString()
+
     let cursorAsDrawingObjects (window : WindowView) =
         match window.Cursor with
         | Visible cursor ->
@@ -48,8 +51,8 @@ module RenderWindows =
                     Color = Colors.defaultColorscheme.Foreground
                 } :: if window.Buffer.Length > 0
                      then [DrawingObject.Text {
-                        Text = window.Buffer.[0].[0].ToString() // TODO buggy
-                        UpperLeftCorner = PointGrid.originPoint
+                        Text = getCharacter window.Buffer cell
+                        UpperLeftCorner = GridConvert.upperLeftCornerOf cell
                         Color = Colors.defaultColorscheme.Background
                      }]
                      else []

--- a/src/Void.ViewModel/ViewModel.fs
+++ b/src/Void.ViewModel/ViewModel.fs
@@ -1,8 +1,9 @@
 ﻿namespace Void.ViewModel
 
 module Sizing =
+    open Void.Core
     open Void.Core.CellGrid
-    let defaultViewSize = { Rows = 26; Columns = 80 }
+    let defaultViewSize = { Rows = 26<mRow>; Columns = 80<mColumn> }
     let defaultViewArea = { UpperLeftCell = originCell; Dimensions = defaultViewSize }
 
 module ViewModel = // TODO name suspect at this point
@@ -29,11 +30,11 @@ module ViewModel = // TODO name suspect at this point
 
     let upperLeftCellOfCommandBar viewModel =
         // TODO this is just hacked together for the moment
-        { Row = CellGrid.lastRow (wholeArea viewModel); Column = 0 }
+        { Row = CellGrid.lastRow (wholeArea viewModel); Column = 0<mColumn> }
 
     let areaOfCommandBarOrNotifications viewModel =
         // TODO this is just hacked together for the moment
         {
             UpperLeftCell = upperLeftCellOfCommandBar viewModel
-            Dimensions = { Rows = 1; Columns = viewModel.Size.Columns }
+            Dimensions = { Rows = 1<mRow>; Columns = viewModel.Size.Columns }
         }

--- a/src/Void.ViewModel/ViewModelMessages.fs
+++ b/src/Void.ViewModel/ViewModelMessages.fs
@@ -18,6 +18,7 @@ type FileOrBufferId = // TODO this is very sketchy right now
 type VMEvent =
     | ViewModelInitialized of MainViewModel // Vim rough equivalent: GUIEnter
     | ViewPortionRendered of PointGrid.Block * seq<DrawingObject>
+    | MultipleViewPortionsRendered of seq<PointGrid.Block * seq<DrawingObject>>
     | BufferLoadedIntoWindow
     interface EventMessage
 

--- a/src/Void.ViewModel/ViewModelMessages.fs
+++ b/src/Void.ViewModel/ViewModelMessages.fs
@@ -22,11 +22,19 @@ type VMEvent =
     interface EventMessage
 
 [<Measure>] type mScreenHeight
+module vmBy =
+    (* Unit of measure types seem to get erased at runtime.
+     * When we need a downcast to work, we need a type that doesn't get erased.
+     * Thus these By* types provide a wrapper. *)
+     type ScreenHeight = ScreenHeight of int<mScreenHeight>
+
+     let screenHeight (x : int) =
+        ScreenHeight (x * 1<mScreenHeight>)
 
 [<RequireQualifiedAccess>]
 type VMCommand =
     | Edit of FileOrBufferId
     | Write of FileOrBufferId
-    | Scroll of Move<mLine>
-    | ScrollHalf of Move<mScreenHeight>
+    | Scroll of Move<By.Line>
+    | ScrollHalf of Move<vmBy.ScreenHeight>
     interface CommandMessage

--- a/src/Void.ViewModel/ViewModelMessages.fs
+++ b/src/Void.ViewModel/ViewModelMessages.fs
@@ -27,7 +27,6 @@ type VMEvent =
 type VMCommand =
     | Edit of FileOrBufferId
     | Write of FileOrBufferId
-    | Move of Motion
     | Scroll of Move<mLine>
     | ScrollHalf of Move<mScreenHeight>
     interface CommandMessage

--- a/src/Void.ViewModel/Void.ViewModel.fsproj
+++ b/src/Void.ViewModel/Void.ViewModel.fsproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\Void.ViewModel.XML</DocumentationFile>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\Void.ViewModel.XML</DocumentationFile>

--- a/src/Void.ViewModel/Void.ViewModel.fsproj
+++ b/src/Void.ViewModel/Void.ViewModel.fsproj
@@ -21,7 +21,8 @@
     <OutputPath>../../build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\Void.ViewModel.XML</DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>

--- a/src/Void.ViewModel/Window.fs
+++ b/src/Void.ViewModel/Window.fs
@@ -23,6 +23,7 @@ module Window =
     type Event =
         | ContentsUpdated of WindowView
         | Initialized of WindowView
+        | CursorMoved of From : Cell * Window : WindowView
         interface EventMessage
 
     [<RequireQualifiedAccess>]
@@ -66,7 +67,9 @@ module Window =
         match event.Message with
         | BufferEvent.Added buffer ->
             loadBufferIntoWindow buffer window
-        | _ -> window, noMessage
+        | BufferEvent.CursorMoved(fromCell, toCell) ->
+            let updatedWindow = { window with Cursor = Visible (CursorView.Block toCell)}
+            updatedWindow, Event.CursorMoved(fromCell, updatedWindow) :> Message
 
     let private scroll (requestSender : RequestSender) window xLines =
         let request : GetWindowContentsRequest = { StartingAtLine = window.TopLineNumber + xLines }

--- a/src/Void.ViewModel/Window.fs
+++ b/src/Void.ViewModel/Window.fs
@@ -23,7 +23,7 @@ module Window =
     type Event =
         | ContentsUpdated of WindowView
         | Initialized of WindowView
-        | CursorMoved of From : Cell * Window : WindowView
+        | CursorMoved of From : Cell * To : Cell * Window : WindowView
         interface EventMessage
 
     [<RequireQualifiedAccess>]
@@ -69,7 +69,7 @@ module Window =
             loadBufferIntoWindow buffer window
         | BufferEvent.CursorMoved(fromCell, toCell) ->
             let updatedWindow = { window with Cursor = Visible (CursorView.Block toCell)}
-            updatedWindow, Event.CursorMoved(fromCell, updatedWindow) :> Message
+            updatedWindow, Event.CursorMoved(fromCell, toCell, updatedWindow) :> Message
 
     let private scroll (requestSender : RequestSender) window xLines =
         let request : GetWindowContentsRequest = { StartingAtLine = window.TopLineNumber + xLines }

--- a/src/Void.ViewModel/Window.fs
+++ b/src/Void.ViewModel/Window.fs
@@ -67,9 +67,12 @@ module Window =
         match event.Message with
         | BufferEvent.Added buffer ->
             loadBufferIntoWindow buffer window
-        | BufferEvent.CursorMoved(fromCell, toCell) ->
-            let updatedWindow = { window with Cursor = Visible (CursorView.Block toCell)}
-            updatedWindow, Event.CursorMoved(fromCell, toCell, updatedWindow) :> Message
+        | BufferEvent.CursorMoved(fromBufferCell, toBufferCell) ->
+            let firstRow = ``line#->row#`` window.TopLineNumber
+            let fromWindowCell = CellGrid.above fromBufferCell firstRow
+            let toWindowCell = CellGrid.above toBufferCell firstRow
+            let updatedWindow = { window with Cursor = Visible (CursorView.Block toWindowCell)}
+            updatedWindow, Event.CursorMoved(fromWindowCell, toWindowCell, updatedWindow) :> Message
 
     let private scroll (requestSender : RequestSender) window xLines =
         let request : GetWindowContentsRequest = { StartingAtLine = window.TopLineNumber + xLines }

--- a/src/Void.ViewModel/Window.fs
+++ b/src/Void.ViewModel/Window.fs
@@ -40,7 +40,7 @@ module Window =
         }
 
     let private windowInArea window containingArea =
-        { zeroWindowView with Dimensions = (lessRowsBelow 1 containingArea).Dimensions }
+        { zeroWindowView with Dimensions = (lessRowsBelow 1<mRow> containingArea).Dimensions }
 
     let defaultWindowView =
         { zeroWindowView with Dimensions = Sizing.defaultViewSize }
@@ -49,9 +49,9 @@ module Window =
         window.Buffer.Length*1<mLine>
 
     let bufferFrom (windowSize : Dimensions) lines =
-        let truncateToWindowWidth = StringUtil.noLongerThan windowSize.Columns
+        let truncateToWindowWidth = StringUtil.noLongerThan (windowSize.Columns / 1<mColumn>)
         lines
-        |> SeqUtil.notMoreThan windowSize.Rows
+        |> SeqUtil.notMoreThan (windowSize.Rows / 1<mRow>)
         |> Seq.map truncateToWindowWidth
         |> Seq.toList
 
@@ -66,6 +66,7 @@ module Window =
         match event.Message with
         | BufferEvent.Added buffer ->
             loadBufferIntoWindow buffer window
+        | _ -> window, noMessage
 
     let private scroll (requestSender : RequestSender) window xLines =
         let request : GetWindowContentsRequest = { StartingAtLine = window.TopLineNumber + xLines }
@@ -97,7 +98,7 @@ module Window =
 
     let scrollHalfScreenHeights requestSender (window : WindowView) movement =
         let toLines (screenHeights : int<mScreenHeight>) =
-            window.Dimensions.Rows / 2 * screenHeights * 1<mLine>/1<mScreenHeight>
+            window.Dimensions.Rows / 2<mScreenHeight> * screenHeights * linePerRow
         match movement with
         | Move.Backward screenHeights ->
             toLines screenHeights |> Move.Backward

--- a/src/Void.ViewModel/Window.fs
+++ b/src/Void.ViewModel/Window.fs
@@ -82,7 +82,7 @@ module Window =
     let scrollByLineMovement requestSender window movement =
         let noScroll = window, noMessage
         match movement with
-        | Move.Backward xLines ->
+        | Move.Backward (By.Line xLines) ->
             let scrollAmount =
                 if window.TopLineNumber > xLines
                 then xLines
@@ -90,7 +90,7 @@ module Window =
             if scrollAmount > 0<mLine>
             then scroll requestSender window -scrollAmount
             else noScroll
-        | Move.Forward xLines ->
+        | Move.Forward (By.Line xLines) ->
             let scrollAmount =
                 if linesInWindow window > xLines
                 then xLines
@@ -102,10 +102,11 @@ module Window =
     let scrollHalfScreenHeights requestSender (window : WindowView) movement =
         let toLines (screenHeights : int<mScreenHeight>) =
             window.Dimensions.Rows / 2<mScreenHeight> * screenHeights * linePerRow
+            |> By.Line
         match movement with
-        | Move.Backward screenHeights ->
+        | Move.Backward (vmBy.ScreenHeight screenHeights) ->
             toLines screenHeights |> Move.Backward
-        | Move.Forward screenHeights ->
+        | Move.Forward (vmBy.ScreenHeight screenHeights) ->
             toLines screenHeights |> Move.Forward
         |> scrollByLineMovement requestSender window
 

--- a/src/Void.ViewModel/Window.fs
+++ b/src/Void.ViewModel/Window.fs
@@ -79,8 +79,17 @@ module Window =
             else
                 let fromWindowCell = CellGrid.above fromBufferCell firstRow
                 let toWindowCell = CellGrid.above toBufferCell firstRow
-                let updatedWindow = { window with Cursor = Visible (CursorView.Block toWindowCell)}
-                updatedWindow, Event.CursorMoved(fromWindowCell, toWindowCell, updatedWindow) :> Message
+                let lastRowInWindow = window.Dimensions.Rows - 1<mRow>
+                if toWindowCell.Row > lastRowInWindow
+                then
+                    let msg = (toWindowCell.Row - lastRowInWindow) * linePerRow
+                              |> By.Line
+                              |> Move.Forward
+                              |> VMCommand.Scroll :> Message
+                    window, msg
+                else
+                    let updatedWindow = { window with Cursor = Visible (CursorView.Block toWindowCell) }
+                    updatedWindow, Event.CursorMoved(fromWindowCell, toWindowCell, updatedWindow) :> Message
 
     let private scroll (requestSender : RequestSender) window xLines =
         let request : GetWindowContentsRequest = { StartingAtLine = window.TopLineNumber + xLines }

--- a/src/Void.ViewModel/Window.fs
+++ b/src/Void.ViewModel/Window.fs
@@ -43,7 +43,7 @@ module Window =
         { zeroWindowView with Dimensions = (lessRowsBelow 1<mRow> containingArea).Dimensions }
 
     let defaultWindowView =
-        { zeroWindowView with Dimensions = Sizing.defaultViewSize }
+        windowInArea zeroWindowView Sizing.defaultViewArea
 
     let private linesInWindow window = 
         window.Buffer.Length*1<mLine>

--- a/src/Void.ViewModel/WindowBufferMap.fs
+++ b/src/Void.ViewModel/WindowBufferMap.fs
@@ -123,5 +123,5 @@ module WindowBufferMap =
             handleGetWindowContentsRequest bus windowBufferMap
             |> bus.subscribeToRequest
 
-            handleCurrentBufferCommandEnvelope<MoveCursor<mRow>> windowBufferMap
+            handleCurrentBufferCommandEnvelope<MoveCursor<ByRow, mRow>> windowBufferMap
             |> bus.subscribe

--- a/src/Void.ViewModel/WindowBufferMap.fs
+++ b/src/Void.ViewModel/WindowBufferMap.fs
@@ -123,5 +123,5 @@ module WindowBufferMap =
             handleGetWindowContentsRequest bus windowBufferMap
             |> bus.subscribeToRequest
 
-            handleCurrentBufferCommandEnvelope<MoveCursor<ByRow, mRow>> windowBufferMap
+            handleCurrentBufferCommandEnvelope<MoveCursor<By.Row>> windowBufferMap
             |> bus.subscribe

--- a/src/Void.ViewModel/WindowBufferMap.fs
+++ b/src/Void.ViewModel/WindowBufferMap.fs
@@ -25,6 +25,13 @@ module WindowBufferMap =
             Windows = Map.empty.Add(0, firstWindow)
         }
 
+    let private getWindowId windowBufferMap bufferId =
+        let windowIdOfMatchingBufferId windowId window =
+            if window.CurrentBufferId = bufferId
+            then Some windowId
+            else None
+        Map.pick windowIdOfMatchingBufferId windowBufferMap.Windows
+
     let private currentWindow windowBufferMap =
         windowBufferMap.Windows.[windowBufferMap.CurrentWindowId]
 
@@ -78,7 +85,17 @@ module WindowBufferMap =
         match event.Message with
         | BufferEvent.Added _ ->
             loadBufferIntoCurrentWindow windowBufferMap event.BufferId
-        | _ -> windowBufferMap, noMessage
+        | unwrappedEvent ->
+            windowBufferMap, {
+                WindowId = getWindowId windowBufferMap event.BufferId
+                Message = unwrappedEvent
+            } :> Message
+
+    let handleCurrentBufferCommandEnvelope<'TBufferCommand when 'TBufferCommand :> BufferMessage> windowBufferMap (InCurrentBuffer (bufferCommand : 'TBufferCommand)) =
+        {
+            BufferId = currentBufferId !windowBufferMap
+            Message = bufferCommand
+        } :> Message
 
     let getWindowContentsResponse getBufferContentsResponse =
         {
@@ -102,5 +119,9 @@ module WindowBufferMap =
             |> bus.subscribe
             Service.wrap windowBufferMap handleBufferEvent
             |> bus.subscribe
+
             handleGetWindowContentsRequest bus windowBufferMap
             |> bus.subscribeToRequest
+
+            handleCurrentBufferCommandEnvelope<MoveCursor<mRow>> windowBufferMap
+            |> bus.subscribe

--- a/src/Void.ViewModel/WindowBufferMap.fs
+++ b/src/Void.ViewModel/WindowBufferMap.fs
@@ -78,6 +78,7 @@ module WindowBufferMap =
         match event.Message with
         | BufferEvent.Added _ ->
             loadBufferIntoCurrentWindow windowBufferMap event.BufferId
+        | _ -> windowBufferMap, noMessage
 
     let getWindowContentsResponse getBufferContentsResponse =
         {

--- a/src/Void.ViewModel/WindowMessages.fs
+++ b/src/Void.ViewModel/WindowMessages.fs
@@ -18,3 +18,15 @@ type GetWindowContentsResponse =
     }
     interface ResponseMessage<GetWindowContentsRequest>
     interface WindowMessage
+
+type WindowEnvelopeMessage<'TBufferMessage when 'TBufferMessage :> BufferMessage> =
+    {
+        WindowId : int
+        Message : 'TBufferMessage
+    }
+    interface EnvelopeMessage<'TBufferMessage>
+
+type CurrentBufferCommandEnvelope<'TBufferMessage when 'TBufferMessage :> BufferMessage> =
+    | InCurrentBuffer of 'TBufferMessage
+    interface EnvelopeMessage<'TBufferMessage>
+    interface CommandMessage

--- a/src/Void/DefaultNormalModeBindings.fs
+++ b/src/Void/DefaultNormalModeBindings.fs
@@ -4,17 +4,19 @@ module DefaultNormalModeBindings =
     open Void.Core
     open Void.ViewModel
 
-    let move movement =
-        MoveCursor movement |> InCurrentBuffer :> CommandMessage
+    let move<'TBy, [<Measure>]'TUom> movement =
+        (MoveCursor movement : MoveCursor<'TBy, 'TUom>)
+        |> InCurrentBuffer :> CommandMessage
     let moveTo place =
-        MoveCursorTo place |> InCurrentBuffer :> CommandMessage
+        MoveCursorTo place
+        |> InCurrentBuffer :> CommandMessage
 
     let commonBindings =
         [
-            [KeyPress.H], move (Move.Backward 1<mCharacter>)
-            [KeyPress.J], move (Move.Forward 1<mLine>)
-            [KeyPress.K], move (Move.Backward 1<mLine>)
-            [KeyPress.L], move (Move.Forward 1<mCharacter>)
+            [KeyPress.H], move<ByColumn, mColumn> (Move.Backward 1<mColumn>)
+            [KeyPress.J], move<ByRow, mRow> (Move.Forward 1<mRow>)
+            [KeyPress.K], move<ByRow, mRow> (Move.Backward 1<mRow>)
+            [KeyPress.L], move<ByColumn, mColumn> (Move.Forward 1<mColumn>)
 
             [KeyPress.Zero], moveTo MoveTo<mCharacter,mLine>.First
             [KeyPress.DollarSign], moveTo MoveTo<mCharacter,mLine>.Last

--- a/src/Void/DefaultNormalModeBindings.fs
+++ b/src/Void/DefaultNormalModeBindings.fs
@@ -4,8 +4,8 @@ module DefaultNormalModeBindings =
     open Void.Core
     open Void.ViewModel
 
-    let move<'TBy, [<Measure>]'TUom> movement =
-        (MoveCursor movement : MoveCursor<'TBy, 'TUom>)
+    let move movement =
+        MoveCursor movement
         |> InCurrentBuffer :> CommandMessage
     let moveTo place =
         MoveCursorTo place
@@ -13,10 +13,10 @@ module DefaultNormalModeBindings =
 
     let commonBindings =
         [
-            [KeyPress.H], move<ByColumn, mColumn> (Move.Backward 1<mColumn>)
-            [KeyPress.J], move<ByRow, mRow> (Move.Forward 1<mRow>)
-            [KeyPress.K], move<ByRow, mRow> (Move.Backward 1<mRow>)
-            [KeyPress.L], move<ByColumn, mColumn> (Move.Forward 1<mColumn>)
+            [KeyPress.H], move (Move.backward By.column 1)
+            [KeyPress.J], move (Move.forward By.row 1)
+            [KeyPress.K], move (Move.backward By.row 1)
+            [KeyPress.L], move (Move.forward By.column 1)
 
             [KeyPress.Zero], moveTo MoveTo<mCharacter,mLine>.First
             [KeyPress.DollarSign], moveTo MoveTo<mCharacter,mLine>.Last
@@ -28,10 +28,10 @@ module DefaultNormalModeBindings =
 
             [KeyPress.ControlL], CoreCommand.Redraw :> CommandMessage
 
-            [KeyPress.ControlD], VMCommand.ScrollHalf (Move.Forward 1<mScreenHeight>) :> CommandMessage
-            [KeyPress.ControlU], VMCommand.ScrollHalf (Move.Backward 1<mScreenHeight>) :> CommandMessage
-            [KeyPress.ControlE], VMCommand.Scroll (Move.Forward 1<mLine>) :> CommandMessage
-            [KeyPress.ControlY], VMCommand.Scroll (Move.Backward 1<mLine>) :> CommandMessage
+            [KeyPress.ControlD], VMCommand.ScrollHalf (Move.forward vmBy.screenHeight 1) :> CommandMessage
+            [KeyPress.ControlU], VMCommand.ScrollHalf (Move.backward vmBy.screenHeight 1) :> CommandMessage
+            [KeyPress.ControlE], VMCommand.Scroll (Move.forward By.line 1) :> CommandMessage
+            [KeyPress.ControlY], VMCommand.Scroll (Move.backward By.line 1) :> CommandMessage
 
             [KeyPress.ShiftZ; KeyPress.ShiftQ], CoreCommand.QuitWithoutSaving :> CommandMessage
         ]

--- a/src/Void/DefaultNormalModeBindings.fs
+++ b/src/Void/DefaultNormalModeBindings.fs
@@ -4,20 +4,25 @@ module DefaultNormalModeBindings =
     open Void.Core
     open Void.ViewModel
 
+    let move movement =
+        MoveCursor movement |> InCurrentBuffer :> CommandMessage
+    let moveTo place =
+        MoveCursorTo place |> InCurrentBuffer :> CommandMessage
+
     let commonBindings =
         [
-            [KeyPress.H], VMCommand.Move (Move.Backward 1<mCharacter>) :> CommandMessage
-            [KeyPress.J], VMCommand.Move (Move.Forward 1<mLine>) :> CommandMessage
-            [KeyPress.K], VMCommand.Move (Move.Backward 1<mLine>) :> CommandMessage
-            [KeyPress.L], VMCommand.Move (Move.Forward 1<mCharacter>) :> CommandMessage
+            [KeyPress.H], move (Move.Backward 1<mCharacter>)
+            [KeyPress.J], move (Move.Forward 1<mLine>)
+            [KeyPress.K], move (Move.Backward 1<mLine>)
+            [KeyPress.L], move (Move.Forward 1<mCharacter>)
 
-            [KeyPress.Zero], VMCommand.Move MoveTo<mCharacter,mLine>.First :> CommandMessage
-            [KeyPress.DollarSign], VMCommand.Move MoveTo<mCharacter,mLine>.Last :> CommandMessage
+            [KeyPress.Zero], moveTo MoveTo<mCharacter,mLine>.First
+            [KeyPress.DollarSign], moveTo MoveTo<mCharacter,mLine>.Last
 
-            [KeyPress.G; KeyPress.G], VMCommand.Move MoveTo<mLine,mBuffer>.First :> CommandMessage
-            [KeyPress.ShiftG], VMCommand.Move MoveTo<mLine,mBuffer>.Last :> CommandMessage
+            [KeyPress.G; KeyPress.G], moveTo MoveTo<mLine,mBuffer>.First
+            [KeyPress.ShiftG], moveTo MoveTo<mLine,mBuffer>.Last
 
-            [KeyPress.G; KeyPress.Q; KeyPress.Q], CoreCommand.FormatCurrentLine :> CommandMessage // TODO this is an abomination of course
+            [KeyPress.G; KeyPress.Q; KeyPress.G; KeyPress.Q], CoreCommand.FormatCurrentLine :> CommandMessage // TODO this is an abomination of course
 
             [KeyPress.ControlL], CoreCommand.Redraw :> CommandMessage
 

--- a/src/Void/Void.fsproj
+++ b/src/Void/Void.fsproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\Void.XML</DocumentationFile>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>../../build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\Void.XML</DocumentationFile>


### PR DESCRIPTION
Move up or down a line in normal mode. Handles boundary cases and scrolls as necessary. Left and right `h`/`l` movement not yet fully supported, though sketched out a little bit. Movements like `10j` are not yet supported by the normal mode bindings capabilities but are available in the backend already.

Also upgrade FsUnit version.
